### PR TITLE
Set UTC upon engine creation

### DIFF
--- a/bemserver_core/csv_io.py
+++ b/bemserver_core/csv_io.py
@@ -81,7 +81,7 @@ class TimeseriesCSVIO:
         """
         data = db.session.execute(
             sqla.select(
-                sqla.func.timezone("UTC", TimeseriesData.timestamp),
+                TimeseriesData.timestamp,
                 TimeseriesData.timeseries_id,
                 TimeseriesData.value,
             ).filter(
@@ -97,7 +97,7 @@ class TimeseriesCSVIO:
             pd.DataFrame(data, columns=('Datetime', 'tsid', 'value'))
             .set_index("Datetime")
         )
-        data_df.index = pd.DatetimeIndex(data_df.index).tz_localize('UTC')
+        data_df.index = pd.DatetimeIndex(data_df.index)
         data_df = data_df.pivot(columns='tsid', values='value')
 
         # Add missing columns, in query order

--- a/bemserver_core/database.py
+++ b/bemserver_core/database.py
@@ -1,5 +1,4 @@
 """Databases: SQLAlchemy database access"""
-
 import sqlalchemy as sqla
 from sqlalchemy.orm import sessionmaker, scoped_session, declarative_base
 
@@ -17,7 +16,12 @@ class DBConnection:
 
     def set_db_url(self, db_url):
         """Set DB URL"""
-        self.engine = sqla.create_engine(db_url, future=True)
+        self.engine = sqla.create_engine(
+            db_url,
+            # Set UTC for all connections
+            connect_args={"options": "-c timezone=utc"},
+            future=True,
+        )
         SESSION_FACTORY.configure(bind=self.engine)
 
     @property

--- a/tests/test_csv_io.py
+++ b/tests/test_csv_io.py
@@ -5,8 +5,6 @@ import datetime as dt
 
 import pytest
 
-from sqlalchemy.sql.expression import func
-
 from bemserver_core.model import TimeseriesData
 from bemserver_core.csv_io import tscsvio
 from bemserver_core.database import db
@@ -42,7 +40,7 @@ class TestTimeseriesCSVIO:
         tscsvio.import_csv(csv_file)
 
         data = db.session.query(
-            func.timezone("UTC", TimeseriesData.timestamp).label("timestamp"),
+            TimeseriesData.timestamp,
             TimeseriesData.timeseries_id,
             TimeseriesData.value,
         ).order_by(
@@ -50,7 +48,10 @@ class TestTimeseriesCSVIO:
             TimeseriesData.timestamp,
         ).all()
 
-        timestamps = [dt.datetime(2020, 1, 1, i) for i in range(4)]
+        timestamps = [
+            dt.datetime(2020, 1, 1, i, tzinfo=dt.timezone.utc)
+            for i in range(4)
+        ]
 
         expected = [
                 (timestamp, ts_0_id, float(idx))


### PR DESCRIPTION
Better than setting it in each request.

Avoids assuming server configuration.