### PR TITLE
Increase password hash column length

### DIFF
--- a/bemserver_core/model/users.py
+++ b/bemserver_core/model/users.py
@@ -23,7 +23,7 @@ class User(Base):
         nullable=False
     )
     password = sqla.Column(
-        sqla.String(80),
+        sqla.String(200),
         nullable=False
     )
     is_admin = sqla.Column(


### PR DESCRIPTION
The generated hash may be longer than 80 chars.