### PR TITLE
Add event permissions

### DIFF
--- a/bemserver_core/authorization.py
+++ b/bemserver_core/authorization.py
@@ -77,6 +77,13 @@ class OpenBarPolarClass:
         return OPEN_BAR.get()
 
 
+@polar_class
+class CampaignPolarClass:
+    @staticmethod
+    def get():
+        return CURRENT_CAMPAIGN.get()
+
+
 def query_builder(model):
     # A "filter" is an object returned from Oso that describes
     # a condition that must hold on an object. This turns an
@@ -130,6 +137,8 @@ def init_authorization(model_classes):
 
     Must be done after model classes are imported
     """
+    AuthMixin.register_class(name="Base")
+
     for cls in model_classes:
         cls.register_class()
 
@@ -140,8 +149,8 @@ def init_authorization(model_classes):
 class AuthMixin:
 
     @classmethod
-    def register_class(cls):
-        auth.register_class(cls)
+    def register_class(cls, *args, **kwargs):
+        auth.register_class(cls, *args, **kwargs)
 
     @classmethod
     def get(cls, **kwargs):

--- a/bemserver_core/exceptions.py
+++ b/bemserver_core/exceptions.py
@@ -11,3 +11,7 @@ class TimeseriesCSVIOError(BEMServerCoreError):
 
 class BEMServerAuthorizationError(BEMServerCoreError):
     """Operation not autorized to current user"""
+
+
+class BEMServerCoreMissingCampaignError(BEMServerCoreError):
+    """Operation requires a Campaign context"""

--- a/bemserver_core/model/__init__.py
+++ b/bemserver_core/model/__init__.py
@@ -6,8 +6,9 @@ from .campaigns import Campaign, UserByCampaign, TimeseriesByCampaign
 from .timeseries import Timeseries
 from .timeseries_data import TimeseriesData
 from .events import (  # noqa
-    EventChannel, EventCategory, EventState, EventLevel,
-    TimeseriesEvent, TimeseriesEventByTimeseries,
+    EventCategory, EventState, EventLevel,
+    EventChannel, EventChannelByCampaign,
+    TimeseriesEvent,
 )
 
 
@@ -21,8 +22,9 @@ __all__ = [
     "EventCategory",
     "EventState",
     "EventLevel",
+    "EventChannel",
+    "EventChannelByCampaign",
     "TimeseriesEvent",
-    "TimeseriesEventByTimeseries",
 ]
 
 
@@ -34,6 +36,12 @@ auth_model_classes = [
     TimeseriesByCampaign,
     Timeseries,
     TimeseriesData,
+    EventCategory,
+    EventState,
+    EventLevel,
+    EventChannel,
+    EventChannelByCampaign,
+    TimeseriesEvent,
 ]
 
 init_authorization(auth_model_classes)

--- a/bemserver_core/model/events.py
+++ b/bemserver_core/model/events.py
@@ -2,18 +2,76 @@
 
 import sqlalchemy as sqla
 import sqlalchemy.orm as sqlaorm
+from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from bemserver_core.database import Base, db
+from bemserver_core.authorization import (
+    auth, AuthMixin, Relation, BEMServerAuthorizationError,
+    get_current_user, get_current_campaign)
+from bemserver_core.exceptions import BEMServerCoreMissingCampaignError
 
 
-class EventChannel(Base):
+class EventChannel(AuthMixin, Base):
     __tablename__ = "event_channels"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80))
 
+    @classmethod
+    def register_class(cls):
+        auth.register_class(
+            cls,
+            fields={
+                "event_channels_by_campaigns": Relation(
+                    kind="many",
+                    other_type="EventChannelByCampaign",
+                    my_field="id",
+                    other_field="event_channel_id",
+                ),
+            },
+        )
 
-class EventCategory(Base):
+    @classmethod
+    def get(cls, *, campaign_id=None, **kwargs):
+        query = super().get(**kwargs)
+        if campaign_id:
+            query = query.join(EventChannelByCampaign).filter_by(
+                campaign_id=campaign_id)
+        return query
+
+
+class EventChannelByCampaign(AuthMixin, Base):
+    """EventChannel x Campaign associations
+
+    Event channels associated with a campaign can be read by all campaign
+    users for the campaign time range.
+    """
+    __tablename__ = "event_channels_by_campaigns"
+    __table_args__ = (
+        sqla.UniqueConstraint("campaign_id", "event_channel_id"),
+    )
+
+    id = sqla.Column(sqla.Integer, primary_key=True)
+    campaign_id = sqla.Column(sqla.ForeignKey("campaigns.id"))
+    event_channel_id = sqla.Column(sqla.ForeignKey("event_channels.id"))
+
+    @classmethod
+    def register_class(cls):
+        auth.register_class(
+            cls,
+            fields={
+                "campaign": Relation(
+                    kind="one",
+                    other_type="Campaign",
+                    my_field="campaign_id",
+                    other_field="id",
+                ),
+            },
+        )
+
+
+class EventCategory(AuthMixin, Base):
     __tablename__ = "event_categories"
 
     id = sqla.Column(sqla.String(80), primary_key=True, nullable=False)
@@ -25,14 +83,14 @@ class EventCategory(Base):
     )
 
 
-class EventState(Base):
+class EventState(AuthMixin, Base):
     __tablename__ = "event_states"
 
     id = sqla.Column(sqla.String(80), primary_key=True, nullable=False)
     description = sqla.Column(sqla.String(250))
 
 
-class EventLevel(Base):
+class EventLevel(AuthMixin, Base):
     __tablename__ = "event_levels"
 
     id = sqla.Column(sqla.String(80), primary_key=True, nullable=False)
@@ -41,18 +99,34 @@ class EventLevel(Base):
 
 @sqlaorm.declarative_mixin
 class Event:
-    """Abstract base class for event classes"""
+    """Abstract base class for event classes
+
+    Channel and timestamp can't be changed after commit. There is no real use
+    case for modifying these and it would screw up the auth layer as these are
+    used by the authorization rules.
+    """
 
     id = sqla.Column(
         sqla.Integer, primary_key=True, autoincrement=True, nullable=False)
 
+    # Use getter/setter to prevent modifying channel after commit
     @sqlaorm.declared_attr
-    def channel_id(cls):
+    def _channel_id(cls):
         return sqla.Column(
             sqla.Integer,
             sqla.ForeignKey("event_channels.id"),
             nullable=False
         )
+
+    @hybrid_property
+    def channel_id(self):
+        return self._channel_id
+
+    @channel_id.setter
+    def channel_id(self, channel_id):
+        if self.id is not None:
+            raise AttributeError("channel_id cannot be modified")
+        self._channel_id = channel_id
 
     @sqlaorm.declared_attr
     def category(cls):
@@ -78,7 +152,18 @@ class Event:
             nullable=False
         )
 
-    timestamp = sqla.Column(sqla.DateTime(timezone=True), nullable=False)
+    # Use getter/setter to prevent modifying timestamp after commit
+    _timestamp = sqla.Column(sqla.DateTime(timezone=True), nullable=False)
+
+    @hybrid_property
+    def timestamp(self):
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, timestamp):
+        if self.id is not None:
+            raise AttributeError("timestamp cannot be modified")
+        self._timestamp = timestamp
 
     source = sqla.Column(sqla.String, nullable=False)
 
@@ -89,6 +174,9 @@ class Event:
         cls, states=("NEW", "ONGOING",), channel_id=None,
         category=None, source=None, level="ERROR"
     ):
+        current_campaign = get_current_campaign()
+        if current_campaign is None:
+            raise BEMServerCoreMissingCampaignError
         if states is None or len(states) <= 0:
             raise ValueError("Missing `state` filter.")
         state_conditions = tuple((cls.state == x) for x in states)
@@ -101,30 +189,118 @@ class Event:
             stmt = stmt.filter(cls.source == source)
         if level is not None:
             stmt = stmt.filter(cls.level == level)
+        if current_campaign.start_time:
+            stmt = stmt.filter(
+                cls.timestamp >= current_campaign.start_time
+            )
+        if current_campaign.end_time:
+            stmt = stmt.filter(
+                cls.timestamp <= current_campaign.end_time
+            )
         return db.session.execute(stmt).all()
 
+    @classmethod
+    def register_class(cls):
+        auth.register_class(
+            cls,
+            fields={
+                "channel": Relation(
+                    kind="one",
+                    other_type="EventChannel",
+                    my_field="channel_id",
+                    other_field="id",
+                ),
+            },
+        )
 
-class TimeseriesEvent(Event, Base):
+    @staticmethod
+    def _check_campaign(campaign, timestamps):
+        for timestamp in timestamps:
+            if (
+                (campaign.start_time and timestamp < campaign.start_time) or
+                (campaign.end_time and timestamp > campaign.end_time)
+            ):
+                raise BEMServerAuthorizationError("Time range out of Campaign")
+
+    @classmethod
+    def get(cls, **kwargs):
+        current_campaign = get_current_campaign()
+        if current_campaign is None:
+            raise BEMServerCoreMissingCampaignError
+        auth.authorize(get_current_user(), "read", current_campaign)
+        query = super().get(**kwargs)
+        if current_campaign.start_time:
+            query = query.filter(
+                cls.timestamp >= current_campaign.start_time
+            )
+        if current_campaign.end_time:
+            query = query.filter(
+                cls.timestamp <= current_campaign.end_time
+            )
+        return query
+
+    @classmethod
+    def new(cls, *args, timestamp, **kwargs):
+        current_campaign = get_current_campaign()
+        if current_campaign is None:
+            raise BEMServerCoreMissingCampaignError
+        cls._check_campaign(current_campaign, (timestamp, ))
+        return super().new(*args, timestamp=timestamp, **kwargs)
+
+    @classmethod
+    def get_by_id(cls, item_id, **kwargs):
+        current_campaign = get_current_campaign()
+        if current_campaign is None:
+            raise BEMServerCoreMissingCampaignError
+        return super().get_by_id(item_id, **kwargs)
+
+    def update(self, **kwargs):
+        current_campaign = get_current_campaign()
+        if current_campaign is None:
+            raise BEMServerCoreMissingCampaignError
+        return super().update(**kwargs)
+
+    def delete(self):
+        current_campaign = get_current_campaign()
+        if current_campaign is None:
+            raise BEMServerCoreMissingCampaignError
+        return super().delete()
+
+
+class TimeseriesEvent(Event, AuthMixin, Base):
     __tablename__ = "timeseries_events"
 
+    timeseries_ids = association_proxy(
+        "timeseries",
+        "timeseries_id",
+        creator=lambda ts_id: TimeseriesEventByTimeseries(timeseries_id=ts_id),
+    )
 
-class TimeseriesEventByTimeseries(Base):
+
+class TimeseriesEventByTimeseries(AuthMixin, Base):
     """TimeseriesEvent x Timeseries associations"""
     __tablename__ = "timeseries_events_by_timeseries"
     __table_args__ = (
         sqla.UniqueConstraint("timeseries_event_id", "timeseries_id"),
     )
 
-    id = sqla.Column(sqla.Integer, primary_key=True)
     timeseries_event_id = sqla.Column(
         sqla.Integer,
-        sqla.ForeignKey("timeseries_events.id"),
-        nullable=True
+        sqla.ForeignKey("timeseries_events.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    timeseries_event = sqla.orm.relationship(
+        "TimeseriesEvent",
+        backref=sqla.orm.backref(
+            "timeseries",
+            passive_deletes=True,
+            cascade="all, delete-orphan"
+        ),
     )
     timeseries_id = sqla.Column(
         sqla.Integer,
-        sqla.ForeignKey("timeseries.id"),
-        nullable=True
+        sqla.ForeignKey("timeseries.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,3 +173,45 @@ def channels():
     db.session.add(channel_2)
     db.session.commit()
     return (channel_1, channel_2)
+
+
+@pytest.fixture
+def event_channels_by_campaigns(database, campaigns, channels):
+    with OpenBar():
+        ecc_1 = model.EventChannelByCampaign(
+            event_channel_id=channels[0].id,
+            campaign_id=campaigns[0].id,
+        )
+        db.session.add(ecc_1)
+        ecc_2 = model.EventChannelByCampaign(
+            event_channel_id=channels[1].id,
+            campaign_id=campaigns[1].id,
+        )
+        db.session.add(ecc_2)
+        db.session.commit()
+    return (ecc_1, ecc_2)
+
+
+@pytest.fixture
+def timeseries_events(database, channels):
+    with OpenBar():
+        ts_event_1 = model.TimeseriesEvent(
+            channel_id=channels[0].id,
+            timestamp=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
+            category="observation_missing",
+            source="src",
+            level="ERROR",
+            state="NEW",
+        )
+        db.session.add(ts_event_1)
+        ts_event_2 = model.TimeseriesEvent(
+            channel_id=channels[1].id,
+            timestamp=dt.datetime(2020, 1, 15, tzinfo=dt.timezone.utc),
+            category="observation_missing",
+            source="src",
+            level="WARNING",
+            state="ONGOING",
+        )
+        db.session.add(ts_event_2)
+        db.session.commit()
+    return (ts_event_1, ts_event_2)

--- a/tests/model/test_events.py
+++ b/tests/model/test_events.py
@@ -3,66 +3,533 @@ import datetime as dt
 
 import pytest
 
-from bemserver_core.model import TimeseriesEvent
+from bemserver_core.model import (
+    EventCategory, EventState, EventLevel,
+    EventChannel, EventChannelByCampaign,
+    TimeseriesEvent,
+)
+from bemserver_core.model.events import TimeseriesEventByTimeseries
+from bemserver_core.authorization import CurrentUser, CurrentCampaign
 from bemserver_core.database import db
+from bemserver_core.exceptions import (
+    BEMServerAuthorizationError, BEMServerCoreMissingCampaignError)
+
+
+class TestEventStateModel:
+
+    def test_event_state_authorizations_as_admin(self, users):
+        admin_user = users[0]
+        assert admin_user.is_admin
+
+        with CurrentUser(admin_user):
+            nb_event_states = len(list(EventState.get()))
+            event_state_1 = EventState.new(
+                id="TEST",
+                description="Event state 1",
+            )
+            db.session.add(event_state_1)
+            db.session.commit()
+            EventState.get_by_id(event_state_1.id)
+            event_states = list(EventState.get())
+            assert len(event_states) == nb_event_states + 1
+            event_state_1.update(name="Super event_state 1")
+            event_state_1.delete()
+            db.session.commit()
+
+    def test_event_state_authorizations_as_user(self, users):
+        user_1 = users[1]
+        assert not user_1.is_admin
+
+        with CurrentUser(user_1):
+            event_states = list(EventState.get())
+            event_state_1 = EventState.get_by_id(event_states[0].id)
+            with pytest.raises(BEMServerAuthorizationError):
+                EventState.new(
+                    id="TEST",
+                    description="Event state 1",
+                )
+            with pytest.raises(BEMServerAuthorizationError):
+                event_state_1.update(name="Super event_state 1")
+            with pytest.raises(BEMServerAuthorizationError):
+                event_state_1.delete()
+
+
+class TestEventLevelModel:
+
+    def test_event_level_authorizations_as_admin(self, users):
+        admin_user = users[0]
+        assert admin_user.is_admin
+
+        with CurrentUser(admin_user):
+            nb_event_levels = len(list(EventLevel.get()))
+            event_level_1 = EventLevel.new(
+                id="TEST",
+                description="Event level 1",
+            )
+            db.session.add(event_level_1)
+            db.session.commit()
+            EventLevel.get_by_id(event_level_1.id)
+            event_levels = list(EventLevel.get())
+            assert len(event_levels) == nb_event_levels + 1
+            event_level_1.update(name="Super event_level 1")
+            event_level_1.delete()
+            db.session.commit()
+
+    def test_event_level_authorizations_as_user(self, users):
+        user_1 = users[1]
+        assert not user_1.is_admin
+
+        with CurrentUser(user_1):
+            event_levels = list(EventLevel.get())
+            event_level_1 = EventLevel.get_by_id(event_levels[0].id)
+            with pytest.raises(BEMServerAuthorizationError):
+                EventLevel.new(
+                    id="TEST",
+                    description="Event level 1",
+                )
+            with pytest.raises(BEMServerAuthorizationError):
+                event_level_1.update(name="Super event_level 1")
+            with pytest.raises(BEMServerAuthorizationError):
+                event_level_1.delete()
+
+
+class TestEventCategoryModel:
+
+    def test_event_category_authorizations_as_admin(self, users):
+        admin_user = users[0]
+        assert admin_user.is_admin
+
+        with CurrentUser(admin_user):
+            nb_event_categories = len(list(EventCategory.get()))
+            event_category_1 = EventCategory.new(
+                id="TEST",
+                description="Event category 1",
+            )
+            db.session.add(event_category_1)
+            db.session.commit()
+            EventCategory.get_by_id(event_category_1.id)
+            event_categories = list(EventCategory.get())
+            assert len(event_categories) == nb_event_categories + 1
+            event_category_1.update(name="Super event_category 1")
+            event_category_1.delete()
+            db.session.commit()
+
+    def test_event_category_authorizations_as_user(self, users):
+        user_1 = users[1]
+        assert not user_1.is_admin
+
+        with CurrentUser(user_1):
+            event_categories = list(EventCategory.get())
+            event_category_1 = EventCategory.get_by_id(event_categories[0].id)
+            with pytest.raises(BEMServerAuthorizationError):
+                EventCategory.new(
+                    id="TEST",
+                    description="Event category 1",
+                )
+            with pytest.raises(BEMServerAuthorizationError):
+                event_category_1.update(name="Super event_category 1")
+            with pytest.raises(BEMServerAuthorizationError):
+                event_category_1.delete()
+
+
+class TestEventChannelModel:
+
+    def test_event_channel_authorizations_as_admin(self, users):
+        admin_user = users[0]
+        assert admin_user.is_admin
+
+        with CurrentUser(admin_user):
+            channel_1 = EventChannel.new(
+                name="Event channel 1",
+            )
+            db.session.add(channel_1)
+            db.session.commit()
+
+            event_channel = EventChannel.get_by_id(channel_1.id)
+            assert event_channel.id == channel_1.id
+            assert event_channel.name == channel_1.name
+            event_channels = list(EventChannel.get())
+            assert len(event_channels) == 1
+            assert event_channels[0].id == channel_1.id
+            event_channel.update(name="Super event channel 1")
+            event_channel.delete()
+            db.session.commit()
+
+    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("event_channels_by_campaigns")
+    def test_event_channel_authorizations_as_user(self, users, channels):
+        user_1 = users[1]
+        assert not user_1.is_admin
+        channel_1 = channels[0]
+        channel_2 = channels[1]
+
+        with CurrentUser(user_1):
+            with pytest.raises(BEMServerAuthorizationError):
+                EventChannel.new(
+                    name="Event channel 1",
+                )
+
+            event_channel = EventChannel.get_by_id(channel_2.id)
+            event_channel_list = list(EventChannel.get())
+            assert len(event_channel_list) == 1
+            assert event_channel_list[0].id == channel_2.id
+            with pytest.raises(BEMServerAuthorizationError):
+                EventChannel.get_by_id(channel_1.id)
+            with pytest.raises(BEMServerAuthorizationError):
+                event_channel.update(name="Super event_channel 1")
+            with pytest.raises(BEMServerAuthorizationError):
+                event_channel.delete()
+
+
+class TestEventModel:
+
+    @pytest.mark.usefixtures("database")
+    @pytest.mark.usefixtures("as_admin")
+    def test_event_list_by_state(self, channels, campaigns):
+        channel_1 = channels[0]
+        campaign_1 = campaigns[0]
+
+        with pytest.raises(BEMServerCoreMissingCampaignError):
+            TimeseriesEvent.list_by_state()
+
+        with CurrentCampaign(campaign_1):
+
+            evts = TimeseriesEvent.list_by_state()
+            assert evts == []
+            evts = TimeseriesEvent.list_by_state(states=("NEW",))
+            assert evts == []
+            evts = TimeseriesEvent.list_by_state(states=("ONGOING",))
+            assert evts == []
+            evts = TimeseriesEvent.list_by_state(states=("CLOSED",))
+            assert evts == []
+
+            evt_1 = TimeseriesEvent.new(
+                channel_id=channel_1.id,
+                timestamp=campaign_1.start_time,
+                category="observation_missing",
+                source="src",
+                level="ERROR",
+                state="NEW",
+            )
+            evt_2 = TimeseriesEvent.new(
+                channel_id=channel_1.id,
+                timestamp=campaign_1.end_time,
+                category="observation_missing",
+                source="src",
+                level="ERROR",
+                state="NEW",
+            )
+            db.session.commit()
+
+            evts = TimeseriesEvent.list_by_state()
+            assert evts == [(evt_1,), (evt_2,)]
+
+            evt_2.state = "CLOSED"
+            evt_3 = TimeseriesEvent.new(
+                channel_id=channel_1.id,
+                timestamp=campaign_1.start_time,
+                category="observation_missing",
+                source="src",
+                level="ERROR",
+                state="ONGOING",
+            )
+            db.session.commit()
+
+            # 2 of 3 events are in NEW or ONGOING state
+            evts = TimeseriesEvent.list_by_state()
+            assert evts == [(evt_1,), (evt_3,)]
+            # one is NEW
+            evts = TimeseriesEvent.list_by_state(states=("NEW",))
+            assert evts == [(evt_1,)]
+            # one is ONGOING
+            evts = TimeseriesEvent.list_by_state(states=("ONGOING",))
+            assert evts == [(evt_3,)]
+            # one is closed
+            evts = TimeseriesEvent.list_by_state(states=("CLOSED",))
+            assert evts == [(evt_2,)]
+
+    @pytest.mark.usefixtures("database")
+    @pytest.mark.usefixtures("as_admin")
+    def test_event_read_only_fields(self, channels, campaigns):
+        """Check channel and timestamp can't be modified after commit
+
+        Also check the getter/setter don't get in the way when querying.
+        This is kind of a "framework test".
+        """
+        channel_1 = channels[0]
+        channel_2 = channels[1]
+        campaign_1 = campaigns[0]
+
+        with CurrentCampaign(campaign_1):
+            evt_1 = TimeseriesEvent.new(
+                channel_id=channel_1.id,
+                timestamp=campaign_1.start_time,
+                category="observation_missing",
+                source="src",
+                level="ERROR",
+                state="NEW",
+            )
+            evt_1.update(timestamp=campaign_1.end_time)
+            evt_1.update(channel_id=channel_2.id)
+            db.session.commit()
+
+            with pytest.raises(AttributeError):
+                evt_1.update(timestamp=campaign_1.end_time)
+            with pytest.raises(AttributeError):
+                evt_1.update(channel_id=channel_2.id)
+
+            tse_list = list(TimeseriesEvent.get(channel_id=2))
+            assert tse_list == [evt_1]
+            tse_list = list(TimeseriesEvent.get(channel_id=1))
+            assert tse_list == []
+            tse_list = list(TimeseriesEvent.get(timestamp=campaign_1.end_time))
+            assert tse_list == [evt_1]
+            tse_list = list(
+                TimeseriesEvent.get(timestamp=campaign_1.start_time))
+            assert tse_list == []
+
+
+class TestEventChannelByCampaignModel:
+
+    def test_event_channels_by_campaign_authorizations_as_admin(
+            self, users, campaigns, channels
+    ):
+        admin_user = users[0]
+        assert admin_user.is_admin
+        campaign_1 = campaigns[0]
+        campaign_2 = campaigns[1]
+        channel_1 = channels[0]
+
+        with CurrentUser(admin_user):
+            ecbc_1 = EventChannelByCampaign.new(
+                event_channel_id=channel_1.id,
+                campaign_id=campaign_1.id,
+            )
+            db.session.add(ecbc_1)
+            db.session.commit()
+
+            ecbc = EventChannelByCampaign.get_by_id(ecbc_1.id)
+            assert ecbc.id == ecbc_1.id
+            ecbcs = list(EventChannelByCampaign.get())
+            assert len(ecbcs) == 1
+            assert ecbcs[0].id == ecbc_1.id
+            ecbc.update(campaign_id=campaign_2.id)
+            ecbc.delete()
+
+    @pytest.mark.usefixtures("users_by_campaigns")
+    def test_event_channels_by_campaign_authorizations_as_user(
+        self, users, campaigns, event_channels_by_campaigns
+    ):
+        user_1 = users[1]
+        assert not user_1.is_admin
+        campaign_1 = campaigns[0]
+        campaign_2 = campaigns[1]
+        ecbc_1 = event_channels_by_campaigns[0]
+        ecbc_2 = event_channels_by_campaigns[1]
+
+        with CurrentUser(user_1):
+            with pytest.raises(BEMServerAuthorizationError):
+                EventChannelByCampaign.new(
+                    event_channel_id=user_1.id,
+                    campaign_id=campaign_2.id,
+                )
+
+            ecbc = EventChannelByCampaign.get_by_id(ecbc_2.id)
+            ecbcs = list(EventChannelByCampaign.get())
+            assert len(ecbcs) == 1
+            assert ecbcs[0].id == ecbc_2.id
+            with pytest.raises(BEMServerAuthorizationError):
+                EventChannelByCampaign.get_by_id(ecbc_1.id)
+            with pytest.raises(BEMServerAuthorizationError):
+                ecbc.update(campaign_id=campaign_1.id)
+            with pytest.raises(BEMServerAuthorizationError):
+                ecbc.delete()
 
 
 class TestTimeseriesEventModel:
 
-    @pytest.mark.usefixtures("database")
-    def test_event_list_by_state(self, channels):
+    @pytest.mark.usefixtures("event_channels_by_campaigns")
+    def test_timeseries_event_authorizations_as_admin(
+        self, users, campaigns, channels, timeseries_events, timeseries,
+    ):
+        admin_user = users[0]
+        assert admin_user.is_admin
+        campaign_1 = campaigns[0]
         channel_1 = channels[0]
+        timeseries_1 = timeseries[0]
+        timeseries_2 = timeseries[1]
+        ts_event_1 = timeseries_events[0]
+        ts_event_2 = timeseries_events[1]
 
-        evts = TimeseriesEvent.list_by_state()
-        assert evts == []
-        evts = TimeseriesEvent.list_by_state(states=("NEW",))
-        assert evts == []
-        evts = TimeseriesEvent.list_by_state(states=("ONGOING",))
-        assert evts == []
-        evts = TimeseriesEvent.list_by_state(states=("CLOSED",))
-        assert evts == []
+        ooc_dt = dt.datetime(2020, 5, 1, tzinfo=dt.timezone.utc)
 
-        evt_1 = TimeseriesEvent.new(
-            channel_id=channel_1.id,
-            timestamp=dt.datetime.now(dt.timezone.utc),
-            category="observation_missing",
-            source="src",
-            level="ERROR",
-            state="NEW",
-        )
-        evt_2 = TimeseriesEvent.new(
-            channel_id=channel_1.id,
-            timestamp=dt.datetime.now(dt.timezone.utc),
-            category="observation_missing",
-            source="src",
-            level="ERROR",
-            state="NEW",
-        )
-        db.session.commit()
+        with CurrentUser(admin_user):
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                TimeseriesEvent.get()
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                TimeseriesEvent.get_by_id(ts_event_1.id)
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                TimeseriesEvent.new(
+                    channel_id=channel_1.id,
+                    timestamp=campaign_1.start_time,
+                    category="observation_missing",
+                    source="src",
+                    level="ERROR",
+                    state="NEW",
+                )
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                ts_event_2.update(level="WARNING", state="ONGOING")
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                ts_event_2.delete()
+            with CurrentCampaign(campaign_1):
+                ts_events = list(TimeseriesEvent.get())
+                assert set(ts_events) == {ts_event_1, ts_event_2}
+                ts_events = list(TimeseriesEvent.get(channel_id=channel_1.id))
+                assert ts_events == [ts_event_1]
+                assert TimeseriesEvent.get_by_id(ts_event_1.id) == ts_event_1
+                with pytest.raises(BEMServerAuthorizationError):
+                    TimeseriesEvent.new(
+                        channel_id=channel_1.id,
+                        timestamp=ooc_dt,
+                        category="observation_missing",
+                        source="src",
+                        level="ERROR",
+                        state="NEW",
+                    )
+                TimeseriesEvent.new(
+                    channel_id=channel_1.id,
+                    timestamp=campaign_1.start_time,
+                    category="observation_missing",
+                    source="src",
+                    level="ERROR",
+                    state="NEW",
+                    timeseries_ids=[timeseries_1.id, timeseries_2.id]
+                )
+                db.session.commit()
+                ts_event_2.update(level="WARNING", state="ONGOING")
+                db.session.commit()
+                ts_event_2.delete()
+                db.session.commit()
 
-        evts = TimeseriesEvent.list_by_state()
-        assert evts == [(evt_1,), (evt_2,)]
+    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("event_channels_by_campaigns")
+    def test_timeseries_event_authorizations_as_user(
+        self, users, campaigns, channels, timeseries_events
+    ):
+        user_1 = users[1]
+        assert not user_1.is_admin
+        campaign_1 = campaigns[0]
+        campaign_2 = campaigns[1]
+        channel_1 = channels[0]
+        channel_2 = channels[1]
+        ts_event_2 = timeseries_events[1]
 
-        evt_2.state = "CLOSED"
-        evt_3 = TimeseriesEvent.new(
-            channel_id=channel_1.id,
-            timestamp=dt.datetime.now(dt.timezone.utc),
-            category="observation_missing",
-            source="src",
-            level="ERROR",
-            state="ONGOING",
-        )
-        db.session.commit()
+        ooc_dt = dt.datetime(2020, 5, 1, tzinfo=dt.timezone.utc)
 
-        # 2 of 3 events are in NEW or ONGOING state
-        evts = TimeseriesEvent.list_by_state()
-        assert evts == [(evt_1,), (evt_3,)]
-        # one is NEW
-        evts = TimeseriesEvent.list_by_state(states=("NEW",))
-        assert evts == [(evt_1,)]
-        # one is ONGOING
-        evts = TimeseriesEvent.list_by_state(states=("ONGOING",))
-        assert evts == [(evt_3,)]
-        # one is closed
-        evts = TimeseriesEvent.list_by_state(states=("CLOSED",))
-        assert evts == [(evt_2,)]
+        with CurrentUser(user_1):
+            # Without Campaing
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                assert not TimeseriesEvent.get()
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                TimeseriesEvent.get_by_id(ts_event_2.id)
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                TimeseriesEvent.new(
+                    channel_id=channel_2.id,
+                    timestamp=campaign_2.start_time,
+                    category="observation_missing",
+                    source="src",
+                    level="ERROR",
+                    state="NEW",
+                )
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                ts_event_2.update(level="WARNING", state="ONGOING")
+            with pytest.raises(BEMServerCoreMissingCampaignError):
+                ts_event_2.delete()
+
+            # Get while not member of Campaign
+            with CurrentCampaign(campaign_1):
+                with pytest.raises(BEMServerAuthorizationError):
+                    TimeseriesEvent.get()
+            with CurrentCampaign(campaign_2):
+                events = list(TimeseriesEvent.get())
+                assert events == [ts_event_2]
+
+            with CurrentCampaign(campaign_2):
+                assert TimeseriesEvent.get_by_id(ts_event_2.id) == ts_event_2
+            # Create with Channel not in Campaign
+            with CurrentCampaign(campaign_2):
+                with pytest.raises(BEMServerAuthorizationError):
+                    TimeseriesEvent.new(
+                        channel_id=channel_1.id,
+                        timestamp=campaign_2.start_time,
+                        category="observation_missing",
+                        source="src",
+                        level="ERROR",
+                        state="NEW",
+                    )
+            # Create with timestamps out of Campaign
+            with CurrentCampaign(campaign_2):
+                with pytest.raises(BEMServerAuthorizationError):
+                    TimeseriesEvent.new(
+                        channel_id=channel_2.id,
+                        timestamp=ooc_dt,
+                        category="observation_missing",
+                        source="src",
+                        level="ERROR",
+                        state="NEW",
+                    )
+            with CurrentCampaign(campaign_2):
+                TimeseriesEvent.new(
+                    channel_id=channel_2.id,
+                    timestamp=campaign_2.start_time,
+                    category="observation_missing",
+                    source="src",
+                    level="ERROR",
+                    state="NEW",
+                )
+            with CurrentCampaign(campaign_2):
+                ts_event_2.update(level="WARNING", state="ONGOING")
+                db.session.commit()
+                ts_event_2.delete()
+                db.session.commit()
+
+
+class TestTimeseriesEventByTimeseriesModel:
+
+    @pytest.mark.usefixtures("event_channels_by_campaigns")
+    def test_timeseries_event_by_timeseries(
+        self, users, campaigns, channels, timeseries,
+    ):
+        """Check TS_event x TS associations are created/deleted.
+
+        This test merely checks the SQLAlchemy framework, more specifically
+        the behaviour of the association table.
+        """
+        admin_user = users[0]
+        assert admin_user.is_admin
+        campaign_1 = campaigns[0]
+        channel_1 = channels[0]
+        timeseries_1 = timeseries[0]
+        timeseries_2 = timeseries[1]
+
+        with CurrentUser(admin_user), CurrentCampaign(campaign_1):
+            assert not list(db.session.query(TimeseriesEventByTimeseries))
+            tse_1 = TimeseriesEvent.new(
+                channel_id=channel_1.id,
+                timestamp=campaign_1.start_time,
+                category="observation_missing",
+                source="src",
+                level="ERROR",
+                state="NEW",
+                timeseries_ids=[timeseries_1.id, timeseries_2.id],
+            )
+            db.session.commit()
+            assert len(
+                list(db.session.query(TimeseriesEventByTimeseries))) == 2
+            tse_1.update(timeseries_ids=[timeseries_2.id])
+            db.session.commit()
+            assert len(
+                list(db.session.query(TimeseriesEventByTimeseries))) == 1
+            tse_1.delete()
+            db.session.commit()
+            assert not list(db.session.query(TimeseriesEventByTimeseries))


### PR DESCRIPTION
Finalize implementation of permissions started in #11 by adding permissions management to `Event` model.