### PR TITLE
Hide Timeseries as TimeseriesByDataState and rename TimeseriesCluster into Timeseries

### DIFF
--- a/bemserver_core/authorization.polar
+++ b/bemserver_core/authorization.polar
@@ -134,14 +134,15 @@ has_relation(tsc: TimeseriesCluster, "cluster", tscpd: TimeseriesClusterProperty
 
 
 resource Timeseries {
-    permissions = ["create", "read", "update", "delete", "read_data", "write_data"];
+    permissions = ["create", "read", "update", "delete"];
     relations = {
         cluster: TimeseriesCluster
     };
 
+    "create" if "read" on "cluster";
     "read" if "read" on "cluster";
-    "read_data" if "read_data" on "cluster";
-    "write_data" if "write_data" on "cluster";
+    "update" if "read" on "cluster";
+    "delete" if "read" on "cluster";
 }
 
 has_relation(tsc: TimeseriesCluster, "cluster", ts: Timeseries) if

--- a/bemserver_core/authorization.polar
+++ b/bemserver_core/authorization.polar
@@ -1,5 +1,5 @@
 # TODO: Investigate potential Oso issue
-# We should't have to write "c_member" and "tscg_member", Oso should infer which
+# We should't have to write "c_member" and "tsg_member", Oso should infer which
 # has_role rule matches which resource type.
 # Same for *_owner.
 
@@ -73,80 +73,80 @@ resource TimeseriesDataState{
 }
 
 
-resource TimeseriesClusterGroupByCampaign {
+resource TimeseriesGroupByCampaign {
     permissions = ["create", "read", "update", "delete"];
 }
 
-has_permission(user: UserActor, "read", tgbc: TimeseriesClusterGroupByCampaign) if
+has_permission(user: UserActor, "read", tgbc: TimeseriesGroupByCampaign) if
     has_role(user, "c_member", tgbc.campaign) and
-    has_role(user, "tscg_member", tgbc.timeseries_cluster_group);
+    has_role(user, "tsg_member", tgbc.timeseries_group);
 
 
-resource TimeseriesClusterGroup {
+resource TimeseriesGroup {
     permissions = ["create", "read", "update", "delete"];
-    roles = ["tscg_member"];
+    roles = ["tsg_member"];
 
-    "read" if "tscg_member";
+    "read" if "tsg_member";
 }
 
-has_role(user: UserActor, "tscg_member", tg: TimeseriesClusterGroup) if
-    tscgbu in tg.timeseries_cluster_groups_by_users and
-    user = tscgbu.user;
+has_role(user: UserActor, "tsg_member", tg: TimeseriesGroup) if
+    tsgbu in tg.timeseries_groups_by_users and
+    user = tsgbu.user;
 
 
-resource TimeseriesClusterGroupByUser {
+resource TimeseriesGroupByUser {
     permissions = ["create", "read", "update", "delete"];
-    roles = ["tscgbu_owner"];
+    roles = ["tsgbu_owner"];
 
-    "read" if "tscgbu_owner";
+    "read" if "tsgbu_owner";
 }
 
-has_role(user: UserActor, "tscgbu_owner", tscgbu: TimeseriesClusterGroupByUser) if
-    user = tscgbu.user;
-
-
-resource TimeseriesCluster {
-    permissions = ["create", "read", "update", "delete", "read_data", "write_data"];
-    relations = {
-        group: TimeseriesClusterGroup
-    };
-
-    "read" if "tscg_member" on "group";
-    "read_data" if "tscg_member" on "group";
-    "write_data" if "tscg_member" on "group";
-}
-
-has_relation(group: TimeseriesClusterGroup, "group", tsc: TimeseriesCluster) if
-    group = tsc.group;
-
-
-resource TimeseriesClusterPropertyData {
-    permissions = ["create", "read", "update", "delete"];
-    relations = {
-        cluster: TimeseriesCluster
-    };
-
-    "read" if "read" on "cluster";
-}
-
-has_relation(tsc: TimeseriesCluster, "cluster", tscpd: TimeseriesClusterPropertyData) if
-    tsc = tscpd.cluster;
+has_role(user: UserActor, "tsgbu_owner", tsgbu: TimeseriesGroupByUser) if
+    user = tsgbu.user;
 
 
 resource Timeseries {
-    permissions = ["create", "read", "update", "delete"];
+    permissions = ["create", "read", "update", "delete", "read_data", "write_data"];
     relations = {
-        cluster: TimeseriesCluster
+        group: TimeseriesGroup
     };
 
-    "create" if "read" on "cluster";
-    "read" if "read" on "cluster";
-    "update" if "read" on "cluster";
-    "delete" if "read" on "cluster";
+    "read" if "tsg_member" on "group";
+    "read_data" if "tsg_member" on "group";
+    "write_data" if "tsg_member" on "group";
 }
 
-has_relation(tsc: TimeseriesCluster, "cluster", ts: Timeseries) if
-    tsc = ts.cluster;
+has_relation(group: TimeseriesGroup, "group", ts: Timeseries) if
+    group = ts.group;
+
+
+resource TimeseriesPropertyData {
+    permissions = ["create", "read", "update", "delete"];
+    relations = {
+        timeseries: Timeseries
+    };
+
+    "read" if "read" on "timeseries";
+}
+
+has_relation(ts: Timeseries, "timeseries", tspd: TimeseriesPropertyData) if
+    ts = tspd.timeseries;
+
+
+resource TimeseriesByDataState {
+    permissions = ["create", "read", "update", "delete"];
+    relations = {
+        timeseries: Timeseries
+    };
+
+    "create" if "read" on "timeseries";
+    "read" if "read" on "timeseries";
+    "update" if "read" on "timeseries";
+    "delete" if "read" on "timeseries";
+}
+
+has_relation(ts: Timeseries, "timeseries", tsbds: TimeseriesByDataState) if
+    ts = tsbds.timeseries;
 
 
 resource EventCategory{

--- a/bemserver_core/csv_io.py
+++ b/bemserver_core/csv_io.py
@@ -6,7 +6,12 @@ import sqlalchemy as sqla
 import pandas as pd
 
 from bemserver_core.database import db
-from bemserver_core.model import Timeseries, TimeseriesData
+from bemserver_core.model import (
+    TimeseriesCluster,
+    Timeseries,
+    TimeseriesData,
+    TimeseriesDataState,
+)
 from bemserver_core.authorization import auth, get_current_user
 from bemserver_core.exceptions import TimeseriesCSVIOError
 
@@ -16,11 +21,15 @@ AGGREGATION_FUNCTIONS = ("avg", "sum", "min", "max")
 
 class TimeseriesCSVIO:
     @staticmethod
-    def import_csv(csv_file):
+    def import_csv(csv_file, data_state_id):
         """Import CSV file
 
         :param srt|TextIOBase csv_file: CSV as string or text stream
         """
+        data_state = TimeseriesDataState.get_by_id(data_state_id)
+        if data_state is None:
+            raise TimeseriesCSVIOError("Unknown data state ID")
+
         # If input is not a text stream, then it is a plain string
         # Make it an iterator
         if not isinstance(csv_file, io.TextIOBase):
@@ -34,12 +43,21 @@ class TimeseriesCSVIO:
             raise TimeseriesCSVIOError("Missing headers line") from exc
         if header[0] != "Datetime":
             raise TimeseriesCSVIOError('First column must be "Datetime"')
-        timeseries_l = [db.session.get(Timeseries, col) for col in header[1:]]
-        if None in timeseries_l:
+        tsc_l = [db.session.get(TimeseriesCluster, col) for col in header[1:]]
+        if None in tsc_l:
             raise TimeseriesCSVIOError("Unknown timeseries ID")
 
-        for timeseries in timeseries_l:
-            auth.authorize(get_current_user(), "write_data", timeseries)
+        for tsc in tsc_l:
+            auth.authorize(get_current_user(), "write_data", tsc)
+
+        # Create missing timeseries on the fly
+        tsbds_l = []
+        for tsc in tsc_l:
+            tsbds = tsc.get_timeseries(data_state)
+            if tsbds is None:
+                tsbds = Timeseries.new(cluster_id=tsc.id, data_state=data_state)
+            tsbds_l.append(tsbds)
+        db.session.commit()
 
         datas = []
         for row in reader:
@@ -51,7 +69,7 @@ class TimeseriesCSVIO:
                             "timeseries_id": timeseries.id,
                             "value": row[col + 1],
                         }
-                        for col, timeseries in enumerate(timeseries_l)
+                        for col, timeseries in enumerate(tsbds_l)
                     ]
                 )
             except IndexError as exc:
@@ -71,7 +89,7 @@ class TimeseriesCSVIO:
             raise TimeseriesCSVIOError("Error writing to DB") from exc
 
     @staticmethod
-    def export_csv(start_dt, end_dt, timeseries_ids):
+    def export_csv(start_dt, end_dt, timeseries_ids, data_state_id):
         """Export timeseries data as CSV file
 
         :param datetime start_dt: Time interval lower bound (tz-aware)
@@ -80,20 +98,32 @@ class TimeseriesCSVIO:
 
         Returns csv as a string.
         """
-        timeseries_l = [db.session.get(Timeseries, ts_id) for ts_id in timeseries_ids]
-        if None in timeseries_l:
+        data_state = TimeseriesDataState.get_by_id(data_state_id)
+        if data_state is None:
+            raise TimeseriesCSVIOError("Unknown data state ID")
+
+        tsc_l = [db.session.get(TimeseriesCluster, ts_id) for ts_id in timeseries_ids]
+        if None in tsc_l:
             raise TimeseriesCSVIOError("Unknown timeseries ID")
 
-        for timeseries in timeseries_l:
+        for timeseries in tsc_l:
             auth.authorize(get_current_user(), "read_data", timeseries)
 
+        # Get timeseries ids
+        tsbds_ids = []
+        for tsc in tsc_l:
+            tsbds = tsc.get_timeseries(data_state)
+            if tsbds is not None:
+                tsbds_ids.append(tsbds.id)
+
+        # Get timeseries data
         data = db.session.execute(
             sqla.select(
                 TimeseriesData.timestamp,
                 TimeseriesData.timeseries_id,
                 TimeseriesData.value,
             )
-            .filter(TimeseriesData.timeseries_id.in_(timeseries_ids))
+            .filter(TimeseriesData.timeseries_id.in_(tsbds_ids))
             .filter(start_dt <= TimeseriesData.timestamp)
             .filter(TimeseriesData.timestamp < end_dt)
         ).all()
@@ -118,6 +148,7 @@ class TimeseriesCSVIO:
         start_dt,
         end_dt,
         timeseries_ids,
+        data_state_id,
         bucket_width,
         timezone="UTC",
         aggregation="avg",
@@ -134,16 +165,28 @@ class TimeseriesCSVIO:
 
         Returns csv as a string.
         """
-        timeseries_l = [db.session.get(Timeseries, ts_id) for ts_id in timeseries_ids]
-        if None in timeseries_l:
+        data_state = TimeseriesDataState.get_by_id(data_state_id)
+        if data_state is None:
+            raise TimeseriesCSVIOError("Unknown data state ID")
+
+        tsc_l = [db.session.get(TimeseriesCluster, ts_id) for ts_id in timeseries_ids]
+        if None in tsc_l:
             raise TimeseriesCSVIOError("Unknown timeseries ID")
 
-        for timeseries in timeseries_l:
+        for timeseries in tsc_l:
             auth.authorize(get_current_user(), "read_data", timeseries)
 
         if aggregation not in AGGREGATION_FUNCTIONS:
             raise ValueError(f'Invalid aggregation method "{aggregation}"')
 
+        # Get timeseries ids
+        tsbds_ids = []
+        for tsc in tsc_l:
+            tsbds = tsc.get_timeseries(data_state)
+            if tsbds is not None:
+                tsbds_ids.append(tsbds.id)
+
+        # Get timeseries data
         query = sqla.text(
             "SELECT time_bucket("
             " :bucket_width, timestamp AT TIME ZONE :timezone)"

--- a/bemserver_core/model/__init__.py
+++ b/bemserver_core/model/__init__.py
@@ -2,15 +2,15 @@
 from bemserver_core.authorization import init_authorization
 
 from .users import User
-from .campaigns import Campaign, UserByCampaign, TimeseriesClusterGroupByCampaign
+from .campaigns import Campaign, UserByCampaign, TimeseriesGroupByCampaign
 from .timeseries import (
     TimeseriesDataState,
     TimeseriesProperty,
-    TimeseriesClusterGroup,
-    TimeseriesClusterGroupByUser,
-    TimeseriesCluster,
-    TimeseriesClusterPropertyData,
+    TimeseriesGroup,
+    TimeseriesGroupByUser,
     Timeseries,
+    TimeseriesPropertyData,
+    TimeseriesByDataState,
 )
 from .timeseries_data import TimeseriesData  # noqa
 from .events import (  # noqa
@@ -28,14 +28,14 @@ __all__ = [
     "User",
     "Campaign",
     "UserByCampaign",
-    "TimeseriesClusterGroupByCampaign",
+    "TimeseriesGroupByCampaign",
     "TimeseriesDataState",
     "TimeseriesProperty",
-    "TimeseriesClusterGroup",
-    "TimeseriesClusterGroupByUser",
-    "TimeseriesCluster",
-    "TimeseriesClusterPropertyData",
+    "TimeseriesGroup",
+    "TimeseriesGroupByUser",
     "Timeseries",
+    "TimeseriesPropertyData",
+    "TimeseriesByDataState",
     "TimeseriesData",
     "EventCategory",
     "EventState",
@@ -52,14 +52,14 @@ auth_model_classes = [
     User,
     Campaign,
     UserByCampaign,
-    TimeseriesClusterGroupByCampaign,
+    TimeseriesGroupByCampaign,
     TimeseriesDataState,
     TimeseriesProperty,
-    TimeseriesClusterGroup,
-    TimeseriesClusterGroupByUser,
-    TimeseriesCluster,
-    TimeseriesClusterPropertyData,
+    TimeseriesGroup,
+    TimeseriesGroupByUser,
     Timeseries,
+    TimeseriesPropertyData,
+    TimeseriesByDataState,
     EventCategory,
     EventState,
     EventLevel,

--- a/bemserver_core/model/campaigns.py
+++ b/bemserver_core/model/campaigns.py
@@ -54,23 +54,19 @@ class UserByCampaign(AuthMixin, Base):
         )
 
 
-class TimeseriesClusterGroupByCampaign(AuthMixin, Base):
+class TimeseriesGroupByCampaign(AuthMixin, Base):
     """Timeseries x Campaign associations
 
     Timeseries associated with a campaign can be read/written by all campaign
     users for the campaign time range.
     """
 
-    __tablename__ = "timeseries_cluster_groups_by_campaigns"
-    __table_args__ = (
-        sqla.UniqueConstraint("campaign_id", "timeseries_cluster_group_id"),
-    )
+    __tablename__ = "timeseries_groups_by_campaigns"
+    __table_args__ = (sqla.UniqueConstraint("campaign_id", "timeseries_group_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     campaign_id = sqla.Column(sqla.ForeignKey("campaigns.id"))
-    timeseries_cluster_group_id = sqla.Column(
-        sqla.ForeignKey("timeseries_cluster_groups.id")
-    )
+    timeseries_group_id = sqla.Column(sqla.ForeignKey("timeseries_groups.id"))
 
     @classmethod
     def register_class(cls):
@@ -83,10 +79,10 @@ class TimeseriesClusterGroupByCampaign(AuthMixin, Base):
                     my_field="campaign_id",
                     other_field="id",
                 ),
-                "timeseries_cluster_group": Relation(
+                "timeseries_group": Relation(
                     kind="one",
-                    other_type="TimeseriesClusterGroup",
-                    my_field="timeseries_cluster_group_id",
+                    other_type="TimeseriesGroup",
+                    my_field="timeseries_group_id",
                     other_field="id",
                 ),
             },

--- a/bemserver_core/model/timeseries.py
+++ b/bemserver_core/model/timeseries.py
@@ -32,6 +32,7 @@ class TimeseriesCluster(AuthMixin, Base):
         sqla.ForeignKey("timeseries_cluster_groups.id"), nullable=False
     )
     group = sqla.orm.relationship("TimeseriesClusterGroup")
+    timeseries = sqla.orm.relationship("Timeseries")
 
     @classmethod
     def register_class(cls):
@@ -61,6 +62,9 @@ class TimeseriesCluster(AuthMixin, Base):
                     TimeseriesClusterGroupByUser.user_id == user_id
                 )
         return query
+
+    def get_timeseries(self, data_state):
+        return next((ts for ts in self.timeseries if ts.data_state == data_state), None)
 
 
 class TimeseriesClusterPropertyData(AuthMixin, Base):
@@ -97,7 +101,7 @@ class Timeseries(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     cluster_id = sqla.Column(sqla.ForeignKey("timeseries_clusters.id"), nullable=False)
-    cluster = sqla.orm.relationship("TimeseriesCluster")
+    cluster = sqla.orm.relationship("TimeseriesCluster", back_populates="timeseries")
     data_state_id = sqla.Column(
         sqla.ForeignKey("timeseries_data_states.id"), nullable=False
     )

--- a/bemserver_core/model/timeseries_data.py
+++ b/bemserver_core/model/timeseries_data.py
@@ -6,15 +6,17 @@ from bemserver_core.database import Base
 
 class TimeseriesData(Base):
     __tablename__ = "timeseries_data"
-    __table_args__ = (sqla.PrimaryKeyConstraint("timeseries_id", "timestamp"),)
+    __table_args__ = (
+        sqla.PrimaryKeyConstraint("timeseries_by_data_state_id", "timestamp"),
+    )
 
     timestamp = sqla.Column(sqla.DateTime(timezone=True))
-    timeseries_id = sqla.Column(
+    timeseries_by_data_state_id = sqla.Column(
         sqla.Integer,
-        sqla.ForeignKey("timeseries.id"),
+        sqla.ForeignKey("timeseries_by_data_states.id"),
         nullable=False,
     )
-    timeseries = sqla.orm.relationship("Timeseries")
+    timeseries_by_data_state = sqla.orm.relationship("TimeseriesByDataState")
     value = sqla.Column(sqla.Float)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,12 +101,12 @@ def timeseries_properties(database):
 
 
 @pytest.fixture
-def timeseries_cluster_groups(database):
+def timeseries_groups(database):
     with OpenBar():
-        ts_group_1 = model.TimeseriesClusterGroup.new(
+        ts_group_1 = model.TimeseriesGroup.new(
             name="TS Group 1",
         )
-        ts_group_2 = model.TimeseriesClusterGroup.new(
+        ts_group_2 = model.TimeseriesGroup.new(
             name="TS Group 2",
         )
         db.session.commit()
@@ -114,69 +114,67 @@ def timeseries_cluster_groups(database):
 
 
 @pytest.fixture
-def timeseries_cluster_groups_by_users(database, timeseries_cluster_groups, users):
+def timeseries_groups_by_users(database, timeseries_groups, users):
     with OpenBar():
-        tscgbu_1 = model.TimeseriesClusterGroupByUser.new(
-            timeseries_cluster_group_id=timeseries_cluster_groups[0].id,
+        tsgbu_1 = model.TimeseriesGroupByUser.new(
+            timeseries_group_id=timeseries_groups[0].id,
             user_id=users[0].id,
         )
-        tscgbu_2 = model.TimeseriesClusterGroupByUser.new(
-            timeseries_cluster_group_id=timeseries_cluster_groups[1].id,
+        tsgbu_2 = model.TimeseriesGroupByUser.new(
+            timeseries_group_id=timeseries_groups[1].id,
             user_id=users[1].id,
         )
         db.session.commit()
-    return (tscgbu_1, tscgbu_2)
+    return (tsgbu_1, tsgbu_2)
 
 
 @pytest.fixture(params=[2])
-def timeseries_clusters(request, database, timeseries_cluster_groups):
-    with OpenBar():
-        tsc_l = []
-        for i in range(request.param):
-            tsc_i = model.TimeseriesCluster(
-                name=f"Timeseries cluster {i}",
-                description=f"Test timeseries cluster #{i}",
-                group=timeseries_cluster_groups[i % len(timeseries_cluster_groups)],
-            )
-            tsc_l.append(tsc_i)
-        db.session.add_all(tsc_l)
-        db.session.commit()
-        return tsc_l
-
-
-@pytest.fixture
-def timeseries_cluster_property_data(
-    request, database, timeseries_properties, timeseries_clusters
-):
-    with OpenBar():
-        tscpd_l = []
-        for tsc in timeseries_clusters:
-            tscpd_l.append(
-                model.TimeseriesClusterPropertyData(
-                    cluster_id=tsc.id,
-                    property_id=timeseries_properties[0].id,
-                    value=12,
-                )
-            )
-            tscpd_l.append(
-                model.TimeseriesClusterPropertyData(
-                    cluster_id=tsc.id,
-                    property_id=timeseries_properties[1].id,
-                    value=42,
-                )
-            )
-        db.session.add_all(tscpd_l)
-        db.session.commit()
-        return tscpd_l
-
-
-@pytest.fixture(params=[2])
-def timeseries(request, database, timeseries_clusters):
+def timeseries(request, database, timeseries_groups):
     with OpenBar():
         ts_l = []
         for i in range(request.param):
             ts_i = model.Timeseries(
-                cluster=timeseries_clusters[i % len(timeseries_clusters)],
+                name=f"Timeseries {i}",
+                description=f"Test timeseries #{i}",
+                group=timeseries_groups[i % len(timeseries_groups)],
+            )
+            ts_l.append(ts_i)
+        db.session.add_all(ts_l)
+        db.session.commit()
+        return ts_l
+
+
+@pytest.fixture
+def timeseries_property_data(request, database, timeseries_properties, timeseries):
+    with OpenBar():
+        tspd_l = []
+        for ts in timeseries:
+            tspd_l.append(
+                model.TimeseriesPropertyData(
+                    timeseries_id=ts.id,
+                    property_id=timeseries_properties[0].id,
+                    value=12,
+                )
+            )
+            tspd_l.append(
+                model.TimeseriesPropertyData(
+                    timeseries_id=ts.id,
+                    property_id=timeseries_properties[1].id,
+                    value=42,
+                )
+            )
+        db.session.add_all(tspd_l)
+        db.session.commit()
+        return tspd_l
+
+
+@pytest.fixture(params=[2])
+def timeseries_by_data_states(request, database, timeseries):
+    with OpenBar():
+        ts_l = []
+        for i in range(request.param):
+            ts_i = model.TimeseriesByDataState(
+                timeseries=timeseries[i % len(timeseries)],
                 data_state_id=1,
             )
             ts_l.append(ts_i)
@@ -186,9 +184,7 @@ def timeseries(request, database, timeseries_clusters):
 
 
 @pytest.fixture
-def timeseries_cluster_groups_by_campaigns(
-    database, campaigns, timeseries_cluster_groups
-):
+def timeseries_groups_by_campaigns(database, campaigns, timeseries_groups):
     """Create timeseries groups x campaigns associations
 
     Example:
@@ -197,17 +193,17 @@ def timeseries_cluster_groups_by_campaigns(
          timeseries x campaigns = [
             TG1 x C1,
             TG2 x C2,
-            TG2 x C1,
+            TG3 x C1,
             TG4 x C2,
             TG5 x C1,
         ]
     """
     with OpenBar():
         tbc_l = []
-        for idx, tscg_i in enumerate(timeseries_cluster_groups):
+        for idx, tsg_i in enumerate(timeseries_groups):
             campaign = campaigns[idx % len(campaigns)]
-            tbc = model.TimeseriesClusterGroupByCampaign.new(
-                timeseries_cluster_group_id=tscg_i.id,
+            tbc = model.TimeseriesGroupByCampaign.new(
+                timeseries_group_id=tsg_i.id,
                 campaign_id=campaign.id,
             )
             tbc_l.append(tbc)

--- a/tests/model/test_campaigns.py
+++ b/tests/model/test_campaigns.py
@@ -4,7 +4,7 @@ import pytest
 from bemserver_core.model import (
     Campaign,
     UserByCampaign,
-    TimeseriesClusterGroupByCampaign,
+    TimeseriesGroupByCampaign,
 )
 from bemserver_core.database import db
 from bemserver_core.authorization import CurrentUser
@@ -111,57 +111,57 @@ class TestUserByCampaignModel:
                 ubc.delete()
 
 
-class TestTimeseriesClusterGroupByCampaignModel:
-    def test_timeseries_cluster_group_by_campaign_authorizations_as_admin(
-        self, users, campaigns, timeseries_cluster_groups
+class TestTimeseriesGroupByCampaignModel:
+    def test_timeseries_group_by_campaign_authorizations_as_admin(
+        self, users, campaigns, timeseries_groups
     ):
         admin_user = users[0]
         assert admin_user.is_admin
         campaign_1 = campaigns[0]
         campaign_2 = campaigns[1]
-        tscg_1 = timeseries_cluster_groups[0]
+        tsg_1 = timeseries_groups[0]
 
         with CurrentUser(admin_user):
-            tgbc_1 = TimeseriesClusterGroupByCampaign.new(
-                timeseries_cluster_group_id=tscg_1.id,
+            tgbc_1 = TimeseriesGroupByCampaign.new(
+                timeseries_group_id=tsg_1.id,
                 campaign_id=campaign_1.id,
             )
             db.session.add(tgbc_1)
             db.session.commit()
 
-            tgbc = TimeseriesClusterGroupByCampaign.get_by_id(tgbc_1.id)
+            tgbc = TimeseriesGroupByCampaign.get_by_id(tgbc_1.id)
             assert tgbc.id == tgbc_1.id
-            tgbcs = list(TimeseriesClusterGroupByCampaign.get())
+            tgbcs = list(TimeseriesGroupByCampaign.get())
             assert len(tgbcs) == 1
             assert tgbcs[0].id == tgbc_1.id
             tgbc.update(campaign_id=campaign_2.id)
             tgbc.delete()
 
-    @pytest.mark.usefixtures("timeseries_cluster_groups_by_users")
+    @pytest.mark.usefixtures("timeseries_groups_by_users")
     @pytest.mark.usefixtures("users_by_campaigns")
-    def test_timeseries_cluster_group_by_campaign_authorizations_as_user(
-        self, users, campaigns, timeseries_cluster_groups_by_campaigns
+    def test_timeseries_group_by_campaign_authorizations_as_user(
+        self, users, campaigns, timeseries_groups_by_campaigns
     ):
         user_1 = users[1]
         assert not user_1.is_admin
         campaign_1 = campaigns[0]
         campaign_2 = campaigns[1]
-        tgbc_1 = timeseries_cluster_groups_by_campaigns[0]
-        tgbc_2 = timeseries_cluster_groups_by_campaigns[1]
+        tgbc_1 = timeseries_groups_by_campaigns[0]
+        tgbc_2 = timeseries_groups_by_campaigns[1]
 
         with CurrentUser(user_1):
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterGroupByCampaign.new(
-                    timeseries_cluster_group_id=user_1.id,
+                TimeseriesGroupByCampaign.new(
+                    timeseries_group_id=user_1.id,
                     campaign_id=campaign_2.id,
                 )
 
-            tgbc = TimeseriesClusterGroupByCampaign.get_by_id(tgbc_2.id)
-            tgbcs = list(TimeseriesClusterGroupByCampaign.get())
+            tgbc = TimeseriesGroupByCampaign.get_by_id(tgbc_2.id)
+            tgbcs = list(TimeseriesGroupByCampaign.get())
             assert len(tgbcs) == 1
             assert tgbcs[0].id == tgbc_2.id
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterGroupByCampaign.get_by_id(tgbc_1.id)
+                TimeseriesGroupByCampaign.get_by_id(tgbc_1.id)
             with pytest.raises(BEMServerAuthorizationError):
                 tgbc.update(campaign_id=campaign_1.id)
             with pytest.raises(BEMServerAuthorizationError):

--- a/tests/model/test_timeseries.py
+++ b/tests/model/test_timeseries.py
@@ -4,11 +4,11 @@ import pytest
 from bemserver_core.model import (
     TimeseriesProperty,
     TimeseriesDataState,
-    TimeseriesClusterGroup,
-    TimeseriesClusterGroupByUser,
-    TimeseriesCluster,
-    TimeseriesClusterPropertyData,
+    TimeseriesGroup,
+    TimeseriesGroupByUser,
     Timeseries,
+    TimeseriesPropertyData,
+    TimeseriesByDataState,
 )
 from bemserver_core.database import db
 from bemserver_core.authorization import CurrentUser
@@ -85,315 +85,307 @@ class TestTimeseriesDataStateModel:
                 ts_data_state_1.delete()
 
 
-class TestTimeseriesClusterGroupModel:
-    def test_timeseries_cluster_group_authorizations_as_admin(self, users):
+class TestTimeseriesGroupModel:
+    def test_timeseries_group_authorizations_as_admin(self, users):
         admin_user = users[0]
         assert admin_user.is_admin
 
         with CurrentUser(admin_user):
-            tscg_1 = TimeseriesClusterGroup.new(
+            tsg_1 = TimeseriesGroup.new(
                 name="TS Group 1",
             )
-            db.session.add(tscg_1)
+            db.session.add(tsg_1)
             db.session.commit()
 
-            timeseries_cluster_group = TimeseriesClusterGroup.get_by_id(tscg_1.id)
-            assert timeseries_cluster_group.id == tscg_1.id
-            assert timeseries_cluster_group.name == tscg_1.name
-            timeseries_cluster_groups = list(TimeseriesClusterGroup.get())
-            assert len(timeseries_cluster_groups) == 1
-            assert timeseries_cluster_groups[0].id == tscg_1.id
-            timeseries_cluster_group.update(name="Super timeseries cluster 1")
-            timeseries_cluster_group.delete()
+            timeseries_group = TimeseriesGroup.get_by_id(tsg_1.id)
+            assert timeseries_group.id == tsg_1.id
+            assert timeseries_group.name == tsg_1.name
+            timeseries_groups = list(TimeseriesGroup.get())
+            assert len(timeseries_groups) == 1
+            assert timeseries_groups[0].id == tsg_1.id
+            timeseries_group.update(name="Super timeseries 1")
+            timeseries_group.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("timeseries_cluster_groups_by_users")
-    def test_timeseries_cluster_group_authorizations_as_user(
-        self, users, timeseries_cluster_groups
-    ):
+    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    def test_timeseries_group_authorizations_as_user(self, users, timeseries_groups):
         user_1 = users[1]
         assert not user_1.is_admin
-        tscg_1 = timeseries_cluster_groups[0]
-        tscg_2 = timeseries_cluster_groups[1]
+        tsg_1 = timeseries_groups[0]
+        tsg_2 = timeseries_groups[1]
 
         with CurrentUser(user_1):
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterGroup.new(
+                TimeseriesGroup.new(
                     name="TS Group 1",
                 )
 
-            timeseries_cluster_group = TimeseriesClusterGroup.get_by_id(tscg_2.id)
-            timeseries_cluster_group_list = list(TimeseriesClusterGroup.get())
-            assert len(timeseries_cluster_group_list) == 1
-            assert timeseries_cluster_group_list[0].id == tscg_2.id
+            timeseries_group = TimeseriesGroup.get_by_id(tsg_2.id)
+            timeseries_group_list = list(TimeseriesGroup.get())
+            assert len(timeseries_group_list) == 1
+            assert timeseries_group_list[0].id == tsg_2.id
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterGroup.get_by_id(tscg_1.id)
+                TimeseriesGroup.get_by_id(tsg_1.id)
             with pytest.raises(BEMServerAuthorizationError):
-                timeseries_cluster_group.update(name="Super timeseries cluster 1")
+                timeseries_group.update(name="Super timeseries 1")
             with pytest.raises(BEMServerAuthorizationError):
-                timeseries_cluster_group.delete()
+                timeseries_group.delete()
 
 
-class TestTimeseriesClusterGroupByUserModel:
-    def test_timeseries_cluster_group_by_user_authorizations_as_admin(
-        self, users, timeseries_cluster_groups
+class TestTimeseriesGroupByUserModel:
+    def test_timeseries_group_by_user_authorizations_as_admin(
+        self, users, timeseries_groups
     ):
         admin_user = users[0]
         assert admin_user.is_admin
         user_1 = users[1]
-        timeseries_cluster_group_1 = timeseries_cluster_groups[0]
-        timeseries_cluster_group_2 = timeseries_cluster_groups[1]
+        timeseries_group_1 = timeseries_groups[0]
+        timeseries_group_2 = timeseries_groups[1]
 
         with CurrentUser(admin_user):
-            tgbu_1 = TimeseriesClusterGroupByUser.new(
+            tgbu_1 = TimeseriesGroupByUser.new(
                 user_id=user_1.id,
-                timeseries_cluster_group_id=timeseries_cluster_group_1.id,
+                timeseries_group_id=timeseries_group_1.id,
             )
             db.session.add(tgbu_1)
             db.session.commit()
 
-            tgbu = TimeseriesClusterGroupByUser.get_by_id(tgbu_1.id)
+            tgbu = TimeseriesGroupByUser.get_by_id(tgbu_1.id)
             assert tgbu.id == tgbu_1.id
-            tgbus = list(TimeseriesClusterGroupByUser.get())
+            tgbus = list(TimeseriesGroupByUser.get())
             assert len(tgbus) == 1
             assert tgbus[0].id == tgbu_1.id
-            tgbu.update(timeseries_cluster_group_id=timeseries_cluster_group_2.id)
+            tgbu.update(timeseries_group_id=timeseries_group_2.id)
             tgbu.delete()
 
-    def test_timeseries_cluster_group_by_user_authorizations_as_user(
-        self, users, timeseries_cluster_groups, timeseries_cluster_groups_by_users
+    def test_timeseries_group_by_user_authorizations_as_user(
+        self, users, timeseries_groups, timeseries_groups_by_users
     ):
         user_1 = users[1]
         assert not user_1.is_admin
-        timeseries_cluster_group_1 = timeseries_cluster_groups[0]
-        timeseries_cluster_group_2 = timeseries_cluster_groups[1]
-        tgbu_1 = timeseries_cluster_groups_by_users[0]
-        tgbu_2 = timeseries_cluster_groups_by_users[1]
+        timeseries_group_1 = timeseries_groups[0]
+        timeseries_group_2 = timeseries_groups[1]
+        tgbu_1 = timeseries_groups_by_users[0]
+        tgbu_2 = timeseries_groups_by_users[1]
 
         with CurrentUser(user_1):
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterGroupByUser.new(
+                TimeseriesGroupByUser.new(
                     user_id=user_1.id,
-                    timeseries_cluster_group_id=timeseries_cluster_group_2.id,
+                    timeseries_group_id=timeseries_group_2.id,
                 )
 
-            tgbu = TimeseriesClusterGroupByUser.get_by_id(tgbu_2.id)
-            tgbus = list(TimeseriesClusterGroupByUser.get())
+            tgbu = TimeseriesGroupByUser.get_by_id(tgbu_2.id)
+            tgbus = list(TimeseriesGroupByUser.get())
             assert len(tgbus) == 1
             assert tgbus[0].id == tgbu_2.id
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterGroupByUser.get_by_id(tgbu_1.id)
+                TimeseriesGroupByUser.get_by_id(tgbu_1.id)
             with pytest.raises(BEMServerAuthorizationError):
-                tgbu.update(timeseries_cluster_group_id=timeseries_cluster_group_1.id)
+                tgbu.update(timeseries_group_id=timeseries_group_1.id)
             with pytest.raises(BEMServerAuthorizationError):
                 tgbu.delete()
 
 
-class TestTimeseriesClusterModel:
-    @pytest.mark.usefixtures("timeseries_cluster_groups_by_users")
-    @pytest.mark.usefixtures("timeseries_cluster_groups_by_campaigns")
-    def test_timeseries_cluster_filter_by_campaign_or_user(
-        self, users, timeseries_clusters, campaigns
-    ):
+class TestTimeseriesModel:
+    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    @pytest.mark.usefixtures("timeseries_groups_by_campaigns")
+    def test_timeseries_filter_by_campaign_or_user(self, users, timeseries, campaigns):
         admin_user = users[0]
         assert admin_user.is_admin
         campaign_1 = campaigns[0]
         campaign_2 = campaigns[1]
         user_1 = users[1]
-        ts_1 = timeseries_clusters[0]
-        ts_2 = timeseries_clusters[1]
+        ts_1 = timeseries[0]
+        ts_2 = timeseries[1]
 
         with CurrentUser(admin_user):
-            ts_l = list(TimeseriesCluster.get(campaign_id=campaign_1.id))
+            ts_l = list(Timeseries.get(campaign_id=campaign_1.id))
             assert len(ts_l) == 1
             assert ts_l[0] == ts_1
 
         with CurrentUser(admin_user):
-            ts_l = list(TimeseriesCluster.get(user_id=user_1.id))
+            ts_l = list(Timeseries.get(user_id=user_1.id))
             assert len(ts_l) == 1
             assert ts_l[0] == ts_2
 
         with CurrentUser(admin_user):
-            ts_l = list(
-                TimeseriesCluster.get(user_id=user_1.id, campaign_id=campaign_2.id)
-            )
+            ts_l = list(Timeseries.get(user_id=user_1.id, campaign_id=campaign_2.id))
             assert len(ts_l) == 1
             assert ts_l[0] == ts_2
 
-    def test_timeseries_cluster_authorizations_as_admin(
-        self, users, timeseries_cluster_groups
-    ):
+    def test_timeseries_authorizations_as_admin(self, users, timeseries_groups):
         admin_user = users[0]
         assert admin_user.is_admin
-        tscg_1 = timeseries_cluster_groups[0]
+        tsg_1 = timeseries_groups[0]
 
         with CurrentUser(admin_user):
-            ts_1 = TimeseriesCluster.new(
+            ts_1 = Timeseries.new(
                 name="Timeseries 1",
-                group_id=tscg_1.id,
+                group_id=tsg_1.id,
             )
             db.session.add(ts_1)
             db.session.commit()
 
-            tsc = TimeseriesCluster.get_by_id(ts_1.id)
-            assert tsc.id == ts_1.id
-            assert tsc.name == ts_1.name
-            ts_l = list(TimeseriesCluster.get())
+            ts = Timeseries.get_by_id(ts_1.id)
+            assert ts.id == ts_1.id
+            assert ts.name == ts_1.name
+            ts_l = list(Timeseries.get())
             assert len(ts_l) == 1
             assert ts_l[0].id == ts_1.id
-            tsc.update(name="Super timeseries cluster 1")
-            tsc.delete()
+            ts.update(name="Super timeseries 1")
+            ts.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("timeseries_cluster_groups_by_users")
-    def test_timeseries_cluster_authorizations_as_user(
-        self, users, timeseries_clusters, timeseries_cluster_groups
+    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    def test_timeseries_authorizations_as_user(
+        self, users, timeseries, timeseries_groups
     ):
         user_1 = users[1]
         assert not user_1.is_admin
-        tsc_1 = timeseries_clusters[0]
-        tsc_2 = timeseries_clusters[1]
-        tscg_1 = timeseries_cluster_groups[0]
+        ts_1 = timeseries[0]
+        ts_2 = timeseries[1]
+        tsg_1 = timeseries_groups[0]
 
         with CurrentUser(user_1):
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesCluster.new(
+                Timeseries.new(
                     name="Timeseries 1",
-                    group_id=tscg_1.id,
+                    group_id=tsg_1.id,
                 )
 
-            timeseries = TimeseriesCluster.get_by_id(tsc_2.id)
-            timeseries_list = list(TimeseriesCluster.get())
+            timeseries = Timeseries.get_by_id(ts_2.id)
+            timeseries_list = list(Timeseries.get())
             assert len(timeseries_list) == 1
-            assert timeseries_list[0].id == tsc_2.id
+            assert timeseries_list[0].id == ts_2.id
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesCluster.get_by_id(tsc_1.id)
+                Timeseries.get_by_id(ts_1.id)
             with pytest.raises(BEMServerAuthorizationError):
                 timeseries.update(name="Super timeseries 1")
             with pytest.raises(BEMServerAuthorizationError):
                 timeseries.delete()
 
 
-class TestTimeseriesClusterPropertyDataModel:
-    def test_timeseries_cluster_property_data_authorizations_as_admin(
-        self, users, timeseries_clusters, timeseries_properties
+class TestTimeseriesPropertyDataModel:
+    def test_timeseries_property_data_authorizations_as_admin(
+        self, users, timeseries, timeseries_properties
     ):
         admin_user = users[0]
         assert admin_user.is_admin
-        tsc_1 = timeseries_clusters[0]
+        ts_1 = timeseries[0]
         tsp_1 = timeseries_properties[0]
 
         with CurrentUser(admin_user):
-            assert not list(TimeseriesClusterPropertyData.get())
-            tscpd_1 = TimeseriesClusterPropertyData.new(
-                cluster_id=tsc_1.id,
+            assert not list(TimeseriesPropertyData.get())
+            tspd_1 = TimeseriesPropertyData.new(
+                timeseries_id=ts_1.id,
                 property_id=tsp_1.id,
                 value=12,
             )
-            db.session.add(tscpd_1)
+            db.session.add(tspd_1)
             db.session.commit()
 
-            tscpd = TimeseriesClusterPropertyData.get_by_id(tscpd_1.id)
-            assert tscpd.id == tscpd_1.id
-            tscpd_l = list(TimeseriesClusterPropertyData.get())
-            assert len(tscpd_l) == 1
-            assert tscpd_l[0].id == tscpd.id
-            tscpd.update(value=42)
-            tscpd.delete()
+            tspd = TimeseriesPropertyData.get_by_id(tspd_1.id)
+            assert tspd.id == tspd_1.id
+            tspd_l = list(TimeseriesPropertyData.get())
+            assert len(tspd_l) == 1
+            assert tspd_l[0].id == tspd.id
+            tspd.update(value=42)
+            tspd.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("timeseries_cluster_groups_by_users")
-    def test_timeseries_cluster_property_data_authorizations_as_user(
+    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    def test_timeseries_property_data_authorizations_as_user(
         self,
         users,
         timeseries_properties,
-        timeseries_clusters,
-        timeseries_cluster_property_data,
+        timeseries,
+        timeseries_property_data,
     ):
         user_1 = users[1]
         assert not user_1.is_admin
         tsp_1 = timeseries_properties[0]
-        tsc_1 = timeseries_clusters[0]
-        tsc_2 = timeseries_clusters[1]
-        tscpd_1 = timeseries_cluster_property_data[0]
+        ts_1 = timeseries[0]
+        ts_2 = timeseries[1]
+        tspd_1 = timeseries_property_data[0]
 
         with CurrentUser(user_1):
-            assert not list(TimeseriesClusterPropertyData.get(cluster_id=tsc_1.id))
+            assert not list(TimeseriesPropertyData.get(timeseries_id=ts_1.id))
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterPropertyData.new(
-                    cluster_id=tsc_2.id,
+                TimeseriesPropertyData.new(
+                    timeseries_id=ts_2.id,
                     property_id=tsp_1.id,
                     value=12,
                 )
 
-            tscpd_l = list(TimeseriesClusterPropertyData.get(cluster_id=tsc_2.id))
-            assert len(tscpd_l) == 2
-            tscpd_2 = tscpd_l[0]
-            tscpd = TimeseriesClusterPropertyData.get_by_id(tscpd_2.id)
-            assert tscpd.id == tscpd_2.id
+            tspd_l = list(TimeseriesPropertyData.get(timeseries_id=ts_2.id))
+            assert len(tspd_l) == 2
+            tspd_2 = tspd_l[0]
+            tspd = TimeseriesPropertyData.get_by_id(tspd_2.id)
+            assert tspd.id == tspd_2.id
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesClusterPropertyData.get_by_id(tscpd_1.id)
+                TimeseriesPropertyData.get_by_id(tspd_1.id)
             with pytest.raises(BEMServerAuthorizationError):
-                tscpd_2.update(data_state_id=2)
+                tspd_2.update(data_state_id=2)
             with pytest.raises(BEMServerAuthorizationError):
-                tscpd_2.delete()
+                tspd_2.delete()
 
 
-class TestTimeseriesModel:
-    def test_timeseries_authorizations_as_admin(self, users, timeseries_clusters):
+class TestTimeseriesByDataStateModel:
+    def test_timeseries_by_data_state_authorizations_as_admin(self, users, timeseries):
         admin_user = users[0]
         assert admin_user.is_admin
-        tsc_1 = timeseries_clusters[0]
+        ts_1 = timeseries[0]
 
         with CurrentUser(admin_user):
-            ts_1 = Timeseries.new(
-                cluster_id=tsc_1.id,
+            tsbds_1 = TimeseriesByDataState.new(
+                timeseries_id=ts_1.id,
                 data_state_id=1,
             )
-            db.session.add(ts_1)
             db.session.commit()
 
-            ts_ = Timeseries.get_by_id(ts_1.id)
-            assert ts_.id == ts_1.id
-            assert ts_.data_state_id == 1
-            ts_l = list(Timeseries.get())
-            assert len(ts_l) == 1
-            assert ts_l[0].id == ts_.id
-            ts_.update(data_state_id=2)
-            ts_.delete()
+            tsbds = TimeseriesByDataState.get_by_id(tsbds_1.id)
+            assert tsbds.id == tsbds_1.id
+            assert tsbds.data_state_id == 1
+            tsbds_l = list(TimeseriesByDataState.get())
+            assert len(tsbds_l) == 1
+            assert tsbds_l[0].id == tsbds.id
+            tsbds.update(data_state_id=2)
+            db.session.commit()
+            tsbds.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("timeseries_cluster_groups_by_users")
-    def test_timeseries_authorizations_as_user(
-        self, users, timeseries_clusters, timeseries
+    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    def test_timeseries_by_data_state_authorizations_as_user(
+        self, users, timeseries, timeseries_by_data_states
     ):
         user_1 = users[1]
         assert not user_1.is_admin
         ts_1 = timeseries[0]
         ts_2 = timeseries[1]
-        tsc_1 = timeseries_clusters[0]
-        tsc_2 = timeseries_clusters[1]
+        ts_1 = timeseries[0]
+        ts_2 = timeseries[1]
 
         with CurrentUser(user_1):
-            timeseries_list = list(Timeseries.get())
+            timeseries_list = list(TimeseriesByDataState.get())
             assert len(timeseries_list) == 1
             assert timeseries_list[0].id == ts_2.id
-            ts_ = Timeseries.get_by_id(ts_2.id)
-            ts_.update(data_state_id=2)
+            tsbds = TimeseriesByDataState.get_by_id(ts_2.id)
+            tsbds.update(data_state_id=2)
             db.session.commit()
-            ts_.delete()
+            tsbds.delete()
             db.session.commit()
-            Timeseries.new(
-                cluster_id=tsc_2.id,
+            TimeseriesByDataState.new(
+                timeseries_id=ts_2.id,
                 data_state_id=2,
             )
             db.session.commit()
 
-            # Not member of cluster group
+            # Not member of group
             with pytest.raises(BEMServerAuthorizationError):
-                ts_ = Timeseries.new(
-                    cluster_id=tsc_1.id,
+                TimeseriesByDataState.new(
+                    timeseries_id=ts_1.id,
                     data_state_id=1,
                 )
             with pytest.raises(BEMServerAuthorizationError):
-                Timeseries.get_by_id(ts_1.id)
+                TimeseriesByDataState.get_by_id(ts_1.id)


### PR DESCRIPTION
Make the creation of timeseries transparent to the user to expose only TS clusters and data state.

Then rename `TimeseriesCluster` into just `Timeseries` and `Timeseries` into `TimeseriesByDataState`.

This allows a clearer API by hiding some of the logic in here.