### PR TITLE
Rework Campaign model

### DIFF
--- a/bemserver_core/authorization.polar
+++ b/bemserver_core/authorization.polar
@@ -192,11 +192,11 @@ resource Event {
 }
 
 has_permission(user: UserActor, "create", event:Event) if
-    has_role(user, "c_member", event.campaign);
+    has_role(user, "cs_member", event.campaign_scope);
 has_permission(user: UserActor, "read", event:Event) if
-    has_role(user, "c_member", event.campaign);
+    has_role(user, "cs_member", event.campaign_scope);
 has_permission(user: UserActor, "update", event:Event) if
-    has_role(user, "c_member", event.campaign);
+    has_role(user, "cs_member", event.campaign_scope);
 has_permission(user: UserActor, "delete", event:Event) if
-    has_role(user, "c_member", event.campaign);
+    has_role(user, "cs_member", event.campaign_scope);
 

--- a/bemserver_core/authorization.polar
+++ b/bemserver_core/authorization.polar
@@ -73,51 +73,19 @@ resource TimeseriesDataState{
 }
 
 
-resource TimeseriesGroupByCampaign {
-    permissions = ["create", "read", "update", "delete"];
-}
-
-has_permission(user: UserActor, "read", tgbc: TimeseriesGroupByCampaign) if
-    has_role(user, "c_member", tgbc.campaign) and
-    has_role(user, "tsg_member", tgbc.timeseries_group);
-
-
-resource TimeseriesGroup {
-    permissions = ["create", "read", "update", "delete"];
-    roles = ["tsg_member"];
-
-    "read" if "tsg_member";
-}
-
-has_role(user: UserActor, "tsg_member", tg: TimeseriesGroup) if
-    tsgbu in tg.timeseries_groups_by_users and
-    user = tsgbu.user;
-
-
-resource TimeseriesGroupByUser {
-    permissions = ["create", "read", "update", "delete"];
-    roles = ["tsgbu_owner"];
-
-    "read" if "tsgbu_owner";
-}
-
-has_role(user: UserActor, "tsgbu_owner", tsgbu: TimeseriesGroupByUser) if
-    user = tsgbu.user;
-
-
 resource Timeseries {
     permissions = ["create", "read", "update", "delete", "read_data", "write_data"];
     relations = {
-        group: TimeseriesGroup
+        campaign: Campaign
     };
 
-    "read" if "tsg_member" on "group";
-    "read_data" if "tsg_member" on "group";
-    "write_data" if "tsg_member" on "group";
+    "read" if "c_member" on "campaign";
+    "read_data" if "c_member" on "campaign";
+    "write_data" if "c_member" on "campaign";
 }
 
-has_relation(group: TimeseriesGroup, "group", ts: Timeseries) if
-    group = ts.group;
+has_relation(campaign: Campaign, "campaign", ts: Timeseries) if
+    campaign = ts.campaign;
 
 
 resource TimeseriesPropertyData {

--- a/bemserver_core/authorization.polar
+++ b/bemserver_core/authorization.polar
@@ -34,6 +34,29 @@ resource User {
 has_role(_user: UserActor{id: id}, "self", _user: User{id: id});
 
 
+resource UserGroup {
+    permissions = ["create", "read", "update", "delete"];
+    roles = ["ug_member"];
+
+    "read" if "ug_member";
+}
+
+has_role(user: UserActor, "ug_member", ug: UserGroup) if
+    ubug in ug.users_by_user_groups and
+    ubug.user = user;
+
+
+resource UserByUserGroup {
+    permissions = ["create", "read", "update", "delete"];
+    roles = ["ubug_owner"];
+
+    "read" if "ubug_owner";
+}
+
+has_role(user: UserActor, "ubug_owner", ubug: UserByUserGroup) if
+    user = ubug.user;
+
+
 resource Campaign {
     permissions = ["create", "read", "update", "delete"];
     roles = ["c_member"];
@@ -42,19 +65,20 @@ resource Campaign {
 }
 
 has_role(user: UserActor, "c_member", campaign: Campaign) if
-    ubc in campaign.users_by_campaigns and
-    user = ubc.user;
+    ugbc in campaign.user_groups_by_campaigns and
+    ubug in ugbc.user_group.users_by_user_groups and
+    user = ubug.user;
 
 
-resource UserByCampaign {
+resource UserGroupByCampaign {
     permissions = ["create", "read", "update", "delete"];
-    roles = ["ubc_owner"];
+    roles = ["ugbc_owner"];
 
-    "read" if "ubc_owner";
+    "read" if "ugbc_owner";
 }
 
-has_role(user: UserActor, "ubc_owner", ubc: UserByCampaign) if
-    user = ubc.user;
+has_role(user: UserActor, "ugbc_owner", ugbc: UserGroupByCampaign) if
+    has_role(user, "ug_member", ugbc.user_group);
 
 
 resource TimeseriesProperty{

--- a/bemserver_core/authorization.polar
+++ b/bemserver_core/authorization.polar
@@ -172,59 +172,16 @@ resource EventLevel{
 }
 
 
-resource EventChannel {
-    permissions = [
-        "create", "read", "update", "delete",
-        "create_events", "read_events", "update_events", "delete_events",
-    ];
-
-    roles = ["ec_member"];
-
-    "read" if "ec_member";
-    "read_events" if "ec_member";
-    "create_events" if "ec_member";
-    "update_events" if "ec_member";
-    "delete_events" if "ec_member";
-}
-
-has_role(user: UserActor, "ec_member", ec: EventChannel) if
-    ecbu in ec.event_channels_by_users and
-    user = ecbu.user;
-
-
-resource EventChannelByCampaign {
-    permissions = ["create", "read", "update", "delete"];
-    relations = {
-        campaign: Campaign
-    };
-
-    "read" if "c_member" on "campaign";
-}
-
-has_relation(campaign: Campaign, "campaign", ecbc: EventChannelByCampaign) if
-  campaign = ecbc.campaign;
-
-
-resource EventChannelByUser {
-    permissions = ["create", "read", "update", "delete"];
-    roles = ["ecbu_owner"];
-
-    "read" if "ecbu_owner";
-}
-
-has_role(user: UserActor, "ecbu_owner", ecbu: EventChannelByUser) if
-    user = ecbu.user;
-
-
 resource Event {
     permissions = ["create", "read", "update", "delete"];
 }
 
 has_permission(user: UserActor, "create", event:Event) if
-    has_permission(user, "create_events", event.channel);
+    has_role(user, "c_member", event.campaign);
 has_permission(user: UserActor, "read", event:Event) if
-    has_permission(user, "read_events", event.channel);
+    has_role(user, "c_member", event.campaign);
 has_permission(user: UserActor, "update", event:Event) if
-    has_permission(user, "update_events", event.channel);
+    has_role(user, "c_member", event.campaign);
 has_permission(user: UserActor, "delete", event:Event) if
-    has_permission(user, "delete_events", event.channel);
+    has_role(user, "c_member", event.campaign);
+

--- a/bemserver_core/model/__init__.py
+++ b/bemserver_core/model/__init__.py
@@ -2,12 +2,10 @@
 from bemserver_core.authorization import init_authorization
 
 from .users import User
-from .campaigns import Campaign, UserByCampaign, TimeseriesGroupByCampaign
+from .campaigns import Campaign, UserByCampaign
 from .timeseries import (
     TimeseriesDataState,
     TimeseriesProperty,
-    TimeseriesGroup,
-    TimeseriesGroupByUser,
     Timeseries,
     TimeseriesPropertyData,
     TimeseriesByDataState,
@@ -25,11 +23,8 @@ __all__ = [
     "User",
     "Campaign",
     "UserByCampaign",
-    "TimeseriesGroupByCampaign",
     "TimeseriesDataState",
     "TimeseriesProperty",
-    "TimeseriesGroup",
-    "TimeseriesGroupByUser",
     "Timeseries",
     "TimeseriesPropertyData",
     "TimeseriesByDataState",
@@ -46,11 +41,8 @@ auth_model_classes = [
     User,
     Campaign,
     UserByCampaign,
-    TimeseriesGroupByCampaign,
     TimeseriesDataState,
     TimeseriesProperty,
-    TimeseriesGroup,
-    TimeseriesGroupByUser,
     Timeseries,
     TimeseriesPropertyData,
     TimeseriesByDataState,

--- a/bemserver_core/model/__init__.py
+++ b/bemserver_core/model/__init__.py
@@ -17,9 +17,6 @@ from .events import (  # noqa
     EventCategory,
     EventState,
     EventLevel,
-    EventChannel,
-    EventChannelByCampaign,
-    EventChannelByUser,
     Event,
 )
 
@@ -40,9 +37,6 @@ __all__ = [
     "EventCategory",
     "EventState",
     "EventLevel",
-    "EventChannel",
-    "EventChannelByCampaign",
-    "EventChannelByUser",
     "Event",
 ]
 
@@ -63,9 +57,6 @@ auth_model_classes = [
     EventCategory,
     EventState,
     EventLevel,
-    EventChannel,
-    EventChannelByCampaign,
-    EventChannelByUser,
     Event,
 ]
 

--- a/bemserver_core/model/__init__.py
+++ b/bemserver_core/model/__init__.py
@@ -1,8 +1,8 @@
 """Model"""
 from bemserver_core.authorization import init_authorization
 
-from .users import User
-from .campaigns import Campaign, UserByCampaign
+from .users import User, UserGroup, UserByUserGroup
+from .campaigns import Campaign, UserGroupByCampaign
 from .timeseries import (
     TimeseriesDataState,
     TimeseriesProperty,
@@ -21,8 +21,10 @@ from .events import (  # noqa
 
 __all__ = [
     "User",
+    "UserGroup",
+    "UserByUserGroup",
     "Campaign",
-    "UserByCampaign",
+    "UserGroupByCampaign",
     "TimeseriesDataState",
     "TimeseriesProperty",
     "Timeseries",
@@ -39,8 +41,10 @@ __all__ = [
 # Register classes for authorization
 auth_model_classes = [
     User,
+    UserGroup,
+    UserByUserGroup,
     Campaign,
-    UserByCampaign,
+    UserGroupByCampaign,
     TimeseriesDataState,
     TimeseriesProperty,
     Timeseries,

--- a/bemserver_core/model/__init__.py
+++ b/bemserver_core/model/__init__.py
@@ -2,7 +2,12 @@
 from bemserver_core.authorization import init_authorization
 
 from .users import User, UserGroup, UserByUserGroup
-from .campaigns import Campaign, UserGroupByCampaign
+from .campaigns import (
+    Campaign,
+    CampaignScope,
+    UserGroupByCampaign,
+    UserGroupByCampaignScope,
+)
 from .timeseries import (
     TimeseriesDataState,
     TimeseriesProperty,
@@ -24,7 +29,9 @@ __all__ = [
     "UserGroup",
     "UserByUserGroup",
     "Campaign",
+    "CampaignScope",
     "UserGroupByCampaign",
+    "UserGroupByCampaignScope",
     "TimeseriesDataState",
     "TimeseriesProperty",
     "Timeseries",
@@ -44,7 +51,9 @@ auth_model_classes = [
     UserGroup,
     UserByUserGroup,
     Campaign,
+    CampaignScope,
     UserGroupByCampaign,
+    UserGroupByCampaignScope,
     TimeseriesDataState,
     TimeseriesProperty,
     Timeseries,

--- a/bemserver_core/model/campaigns.py
+++ b/bemserver_core/model/campaigns.py
@@ -19,9 +19,9 @@ class Campaign(AuthMixin, Base):
         auth.register_class(
             cls,
             fields={
-                "users_by_campaigns": Relation(
+                "user_groups_by_campaigns": Relation(
                     kind="many",
-                    other_type="UserByCampaign",
+                    other_type="UserGroupByCampaign",
                     my_field="id",
                     other_field="campaign_id",
                 ),
@@ -29,25 +29,25 @@ class Campaign(AuthMixin, Base):
         )
 
 
-class UserByCampaign(AuthMixin, Base):
-    """User x Campaign associations"""
+class UserGroupByCampaign(AuthMixin, Base):
+    """UserGroup x Campaign associations"""
 
-    __tablename__ = "users_by_campaigns"
-    __table_args__ = (sqla.UniqueConstraint("campaign_id", "user_id"),)
+    __tablename__ = "user_groups_by_campaigns"
+    __table_args__ = (sqla.UniqueConstraint("campaign_id", "user_group_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     campaign_id = sqla.Column(sqla.ForeignKey("campaigns.id"), nullable=False)
-    user_id = sqla.Column(sqla.ForeignKey("users.id"), nullable=False)
+    user_group_id = sqla.Column(sqla.ForeignKey("user_groups.id"), nullable=False)
 
     @classmethod
     def register_class(cls):
         auth.register_class(
             cls,
             fields={
-                "user": Relation(
+                "user_group": Relation(
                     kind="one",
-                    other_type="User",
-                    my_field="user_id",
+                    other_type="UserGroup",
+                    my_field="user_group_id",
                     other_field="id",
                 ),
             },

--- a/bemserver_core/model/campaigns.py
+++ b/bemserver_core/model/campaigns.py
@@ -52,38 +52,3 @@ class UserByCampaign(AuthMixin, Base):
                 ),
             },
         )
-
-
-class TimeseriesGroupByCampaign(AuthMixin, Base):
-    """Timeseries x Campaign associations
-
-    Timeseries associated with a campaign can be read/written by all campaign
-    users for the campaign time range.
-    """
-
-    __tablename__ = "timeseries_groups_by_campaigns"
-    __table_args__ = (sqla.UniqueConstraint("campaign_id", "timeseries_group_id"),)
-
-    id = sqla.Column(sqla.Integer, primary_key=True)
-    campaign_id = sqla.Column(sqla.ForeignKey("campaigns.id"))
-    timeseries_group_id = sqla.Column(sqla.ForeignKey("timeseries_groups.id"))
-
-    @classmethod
-    def register_class(cls):
-        auth.register_class(
-            cls,
-            fields={
-                "campaign": Relation(
-                    kind="one",
-                    other_type="Campaign",
-                    my_field="campaign_id",
-                    other_field="id",
-                ),
-                "timeseries_group": Relation(
-                    kind="one",
-                    other_type="TimeseriesGroup",
-                    my_field="timeseries_group_id",
-                    other_field="id",
-                ),
-            },
-        )

--- a/bemserver_core/model/events.py
+++ b/bemserver_core/model/events.py
@@ -38,22 +38,22 @@ class Event(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True, autoincrement=True, nullable=False)
 
-    # Use getter/setter to prevent modifying campaign after commit
+    # Use getter/setter to prevent modifying campaign_scope after commit
     @sqlaorm.declared_attr
-    def _campaign_id(cls):
+    def _campaign_scope_id(cls):
         return sqla.Column(
-            sqla.Integer, sqla.ForeignKey("campaigns.id"), nullable=False
+            sqla.Integer, sqla.ForeignKey("campaign_scopes.id"), nullable=False
         )
 
     @hybrid_property
-    def campaign_id(self):
-        return self._campaign_id
+    def campaign_scope_id(self):
+        return self._campaign_scope_id
 
-    @campaign_id.setter
-    def campaign_id(self, campaign_id):
+    @campaign_scope_id.setter
+    def campaign_scope_id(self, campaign_scope_id):
         if self.id is not None:
-            raise AttributeError("campaign_id cannot be modified")
-        self._campaign_id = campaign_id
+            raise AttributeError("campaign_scope_id cannot be modified")
+        self._campaign_scope_id = campaign_scope_id
 
     @sqlaorm.declared_attr
     def category(cls):
@@ -95,10 +95,10 @@ class Event(AuthMixin, Base):
         auth.register_class(
             cls,
             fields={
-                "campaign": Relation(
+                "campaign_scope": Relation(
                     kind="one",
-                    other_type="Campaign",
-                    my_field="campaign_id",
+                    other_type="CampaignScope",
+                    my_field="campaign_scope_id",
                     other_field="id",
                 ),
             },

--- a/bemserver_core/model/events.py
+++ b/bemserver_core/model/events.py
@@ -4,7 +4,7 @@ import sqlalchemy as sqla
 import sqlalchemy.orm as sqlaorm
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from bemserver_core.database import Base, db
+from bemserver_core.database import Base
 from bemserver_core.authorization import auth, AuthMixin, Relation
 
 
@@ -89,32 +89,6 @@ class Event(AuthMixin, Base):
     source = sqla.Column(sqla.String, nullable=False)
 
     description = sqla.Column(sqla.String(250))
-
-    @classmethod
-    def list_by_state(
-        cls,
-        states=(
-            "NEW",
-            "ONGOING",
-        ),
-        campaign_id=None,
-        category=None,
-        source=None,
-        level="ERROR",
-    ):
-        if states is None or len(states) <= 0:
-            raise ValueError("Missing `state` filter.")
-        state_conditions = tuple((cls.state == x) for x in states)
-        stmt = sqla.select(cls).filter(sqla.or_(*state_conditions))
-        if campaign_id is not None:
-            stmt = stmt.filter(cls.campaign_id == campaign_id)
-        if category is not None:
-            stmt = stmt.filter(cls.category == category)
-        if source is not None:
-            stmt = stmt.filter(cls.source == source)
-        if level is not None:
-            stmt = stmt.filter(cls.level == level)
-        return db.session.execute(stmt).all()
 
     @classmethod
     def register_class(cls):

--- a/bemserver_core/model/timeseries.py
+++ b/bemserver_core/model/timeseries.py
@@ -3,7 +3,8 @@ import sqlalchemy as sqla
 
 from bemserver_core.database import Base
 from bemserver_core.authorization import AuthMixin, auth, Relation
-from bemserver_core.model.campaigns import UserByCampaign
+from bemserver_core.model.users import UserGroup, UserByUserGroup
+from bemserver_core.model.campaigns import UserGroupByCampaign
 
 
 class TimeseriesProperty(AuthMixin, Base):
@@ -52,8 +53,10 @@ class Timeseries(AuthMixin, Base):
         if user_id:
             query = (
                 query.join(cls.campaign)
-                .join(UserByCampaign)
-                .filter(UserByCampaign.user_id == user_id)
+                .join(UserGroupByCampaign)
+                .join(UserGroup)
+                .join(UserByUserGroup)
+                .filter(UserByUserGroup.user_id == user_id)
             )
         return query
 

--- a/bemserver_core/model/users.py
+++ b/bemserver_core/model/users.py
@@ -4,7 +4,7 @@ import sqlalchemy as sqla
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from bemserver_core.database import Base
-from bemserver_core.authorization import AuthMixin, auth, get_current_user
+from bemserver_core.authorization import AuthMixin, auth, Relation, get_current_user
 
 
 class User(AuthMixin, Base):
@@ -52,3 +52,55 @@ class User(AuthMixin, Base):
 
     def check_password(self, password: str) -> bool:
         return argon2.verify(password, self.password)
+
+
+class UserGroup(AuthMixin, Base):
+    __tablename__ = "user_groups"
+
+    id = sqla.Column(sqla.Integer, primary_key=True)
+    name = sqla.Column(sqla.String(80), unique=True, nullable=False)
+
+    @classmethod
+    def register_class(cls):
+        auth.register_class(
+            cls,
+            fields={
+                "user_groups_by_campaigns": Relation(
+                    kind="many",
+                    other_type="UserGroupByCampaign",
+                    my_field="id",
+                    other_field="user_group_id",
+                ),
+                "users_by_user_groups": Relation(
+                    kind="many",
+                    other_type="UserByUserGroup",
+                    my_field="id",
+                    other_field="user_group_id",
+                ),
+            },
+        )
+
+
+class UserByUserGroup(AuthMixin, Base):
+    """UserGroup x User associations"""
+
+    __tablename__ = "users_groups_by_users"
+    __table_args__ = (sqla.UniqueConstraint("user_id", "user_group_id"),)
+
+    id = sqla.Column(sqla.Integer, primary_key=True)
+    user_id = sqla.Column(sqla.ForeignKey("users.id"), nullable=False)
+    user_group_id = sqla.Column(sqla.ForeignKey("user_groups.id"), nullable=False)
+
+    @classmethod
+    def register_class(cls):
+        auth.register_class(
+            cls,
+            fields={
+                "user": Relation(
+                    kind="one",
+                    other_type="User",
+                    my_field="user_id",
+                    other_field="id",
+                ),
+            },
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,43 +100,15 @@ def timeseries_properties(database):
     return (ts_p_1, ts_p_2)
 
 
-@pytest.fixture
-def timeseries_groups(database):
-    with OpenBar():
-        ts_group_1 = model.TimeseriesGroup.new(
-            name="TS Group 1",
-        )
-        ts_group_2 = model.TimeseriesGroup.new(
-            name="TS Group 2",
-        )
-        db.session.commit()
-    return (ts_group_1, ts_group_2)
-
-
-@pytest.fixture
-def timeseries_groups_by_users(database, timeseries_groups, users):
-    with OpenBar():
-        tsgbu_1 = model.TimeseriesGroupByUser.new(
-            timeseries_group_id=timeseries_groups[0].id,
-            user_id=users[0].id,
-        )
-        tsgbu_2 = model.TimeseriesGroupByUser.new(
-            timeseries_group_id=timeseries_groups[1].id,
-            user_id=users[1].id,
-        )
-        db.session.commit()
-    return (tsgbu_1, tsgbu_2)
-
-
 @pytest.fixture(params=[2])
-def timeseries(request, database, timeseries_groups):
+def timeseries(request, database, campaigns):
     with OpenBar():
         ts_l = []
         for i in range(request.param):
             ts_i = model.Timeseries(
                 name=f"Timeseries {i}",
                 description=f"Test timeseries #{i}",
-                group=timeseries_groups[i % len(timeseries_groups)],
+                campaign=campaigns[i % len(campaigns)],
             )
             ts_l.append(ts_i)
         db.session.add_all(ts_l)
@@ -181,34 +153,6 @@ def timeseries_by_data_states(request, database, timeseries):
         db.session.add_all(ts_l)
         db.session.commit()
         return ts_l
-
-
-@pytest.fixture
-def timeseries_groups_by_campaigns(database, campaigns, timeseries_groups):
-    """Create timeseries groups x campaigns associations
-
-    Example:
-        campaigns = [C1, C2]
-        timeseries groups = [TG1, TG2, TG3, TG4, TG5]
-         timeseries x campaigns = [
-            TG1 x C1,
-            TG2 x C2,
-            TG3 x C1,
-            TG4 x C2,
-            TG5 x C1,
-        ]
-    """
-    with OpenBar():
-        tbc_l = []
-        for idx, tsg_i in enumerate(timeseries_groups):
-            campaign = campaigns[idx % len(campaigns)]
-            tbc = model.TimeseriesGroupByCampaign.new(
-                timeseries_group_id=tsg_i.id,
-                campaign_id=campaign.id,
-            )
-            tbc_l.append(tbc)
-        db.session.commit()
-    return tbc_l
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,10 +214,10 @@ def timeseries_by_data_states(request, database, timeseries):
 
 
 @pytest.fixture
-def events(database, campaigns):
+def events(database, campaign_scopes):
     with OpenBar():
         ts_event_1 = model.Event.new(
-            campaign_id=campaigns[0].id,
+            campaign_scope_id=campaign_scopes[0].id,
             timestamp=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
             category="observation_missing",
             source="src",
@@ -225,7 +225,7 @@ def events(database, campaigns):
             state="NEW",
         )
         ts_event_2 = model.Event.new(
-            campaign_id=campaigns[1].id,
+            campaign_scope_id=campaign_scopes[1].id,
             timestamp=dt.datetime(2020, 1, 15, tzinfo=dt.timezone.utc),
             category="observation_missing",
             source="src",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,53 +212,10 @@ def timeseries_groups_by_campaigns(database, campaigns, timeseries_groups):
 
 
 @pytest.fixture
-def event_channels(database):
-    with OpenBar():
-        channel_1 = model.EventChannel.new(
-            name="Channel 1",
-        )
-        channel_2 = model.EventChannel.new(
-            name="Channel 2",
-        )
-        db.session.commit()
-        return (channel_1, channel_2)
-
-
-@pytest.fixture
-def event_channels_by_campaigns(database, campaigns, event_channels):
-    with OpenBar():
-        ecc_1 = model.EventChannelByCampaign.new(
-            event_channel_id=event_channels[0].id,
-            campaign_id=campaigns[0].id,
-        )
-        ecc_2 = model.EventChannelByCampaign.new(
-            event_channel_id=event_channels[1].id,
-            campaign_id=campaigns[1].id,
-        )
-        db.session.commit()
-    return (ecc_1, ecc_2)
-
-
-@pytest.fixture
-def event_channels_by_users(database, event_channels, users):
-    with OpenBar():
-        ecbu_1 = model.EventChannelByUser.new(
-            event_channel_id=event_channels[0].id,
-            user_id=users[0].id,
-        )
-        ecbu_2 = model.EventChannelByUser.new(
-            event_channel_id=event_channels[1].id,
-            user_id=users[1].id,
-        )
-        db.session.commit()
-    return (ecbu_1, ecbu_2)
-
-
-@pytest.fixture
-def events(database, event_channels):
+def events(database, campaigns):
     with OpenBar():
         ts_event_1 = model.Event.new(
-            channel_id=event_channels[0].id,
+            campaign_id=campaigns[0].id,
             timestamp=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
             category="observation_missing",
             source="src",
@@ -266,7 +223,7 @@ def events(database, event_channels):
             state="NEW",
         )
         ts_event_2 = model.Event.new(
-            channel_id=event_channels[1].id,
+            campaign_id=campaigns[1].id,
             timestamp=dt.datetime(2020, 1, 15, tzinfo=dt.timezone.utc),
             category="observation_missing",
             source="src",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,19 @@ def as_admin():
 
 
 @pytest.fixture
+def user_groups(database):
+    with OpenBar():
+        user_group_1 = model.UserGroup.new(
+            name="User group 1",
+        )
+        user_group_2 = model.UserGroup.new(
+            name="User group 2",
+        )
+        db.session.commit()
+    return (user_group_1, user_group_2)
+
+
+@pytest.fixture
 def users(database):
     with OpenBar():
         user_1 = model.User.new(
@@ -43,7 +56,6 @@ def users(database):
             is_active=True,
         )
         user_1.set_password("N0rr1s")
-        db.session.commit()
         user_2 = model.User.new(
             name="John",
             email="john@test.com",
@@ -53,6 +65,21 @@ def users(database):
         user_2.set_password("D0e")
         db.session.commit()
     return (user_1, user_2)
+
+
+@pytest.fixture
+def users_by_user_groups(database, users, user_groups):
+    with OpenBar():
+        ubug_1 = model.UserByUserGroup.new(
+            user_id=users[0].id,
+            user_group_id=user_groups[0].id,
+        )
+        ubug_2 = model.UserByUserGroup.new(
+            user_id=users[1].id,
+            user_group_id=user_groups[1].id,
+        )
+        db.session.commit()
+    return (ubug_1, ubug_2)
 
 
 @pytest.fixture
@@ -73,18 +100,18 @@ def campaigns(database):
 
 
 @pytest.fixture
-def users_by_campaigns(database, users, campaigns):
+def user_groups_by_campaigns(database, user_groups, campaigns):
     with OpenBar():
-        ubc_1 = model.UserByCampaign.new(
-            user_id=users[0].id,
+        ugbc_1 = model.UserGroupByCampaign.new(
+            user_group_id=user_groups[0].id,
             campaign_id=campaigns[0].id,
         )
-        ubc_2 = model.UserByCampaign.new(
-            user_id=users[1].id,
+        ugbc_2 = model.UserGroupByCampaign.new(
+            user_group_id=user_groups[1].id,
             campaign_id=campaigns[1].id,
         )
         db.session.commit()
-    return (ubc_1, ubc_2)
+    return (ugbc_1, ugbc_2)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,21 @@ def campaigns(database):
 
 
 @pytest.fixture
+def campaign_scopes(database, campaigns):
+    with OpenBar():
+        cs_1 = model.CampaignScope.new(
+            name="Campaign 1 - Scope 1",
+            campaign_id=campaigns[0].id,
+        )
+        cs_2 = model.CampaignScope.new(
+            name="Campaign 2 - Scope 1",
+            campaign_id=campaigns[1].id,
+        )
+        db.session.commit()
+    return (cs_1, cs_2)
+
+
+@pytest.fixture
 def user_groups_by_campaigns(database, user_groups, campaigns):
     with OpenBar():
         ugbc_1 = model.UserGroupByCampaign.new(
@@ -112,6 +127,21 @@ def user_groups_by_campaigns(database, user_groups, campaigns):
         )
         db.session.commit()
     return (ugbc_1, ugbc_2)
+
+
+@pytest.fixture
+def user_groups_by_campaign_scopes(database, user_groups, campaign_scopes):
+    with OpenBar():
+        ugbcs_1 = model.UserGroupByCampaignScope.new(
+            user_group_id=user_groups[0].id,
+            campaign_scope_id=campaign_scopes[0].id,
+        )
+        ugbcs_2 = model.UserGroupByCampaignScope.new(
+            user_group_id=user_groups[1].id,
+            campaign_scope_id=campaign_scopes[1].id,
+        )
+        db.session.commit()
+    return (ugbcs_1, ugbcs_2)
 
 
 @pytest.fixture
@@ -128,7 +158,7 @@ def timeseries_properties(database):
 
 
 @pytest.fixture(params=[2])
-def timeseries(request, database, campaigns):
+def timeseries(request, database, campaigns, campaign_scopes):
     with OpenBar():
         ts_l = []
         for i in range(request.param):
@@ -136,6 +166,7 @@ def timeseries(request, database, campaigns):
                 name=f"Timeseries {i}",
                 description=f"Test timeseries #{i}",
                 campaign=campaigns[i % len(campaigns)],
+                campaign_scope=campaign_scopes[i % len(campaign_scopes)],
             )
             ts_l.append(ts_i)
         db.session.add_all(ts_l)

--- a/tests/model/test_campaigns.py
+++ b/tests/model/test_campaigns.py
@@ -1,11 +1,8 @@
 """Campaign tests"""
 import pytest
 
-from bemserver_core.model import (
-    Campaign,
-    UserByCampaign,
-    TimeseriesGroupByCampaign,
-)
+from bemserver_core.model import Campaign, UserByCampaign
+
 from bemserver_core.database import db
 from bemserver_core.authorization import CurrentUser
 from bemserver_core.exceptions import BEMServerAuthorizationError
@@ -109,60 +106,3 @@ class TestUserByCampaignModel:
                 ubc.update(campaign_id=campaign_1.id)
             with pytest.raises(BEMServerAuthorizationError):
                 ubc.delete()
-
-
-class TestTimeseriesGroupByCampaignModel:
-    def test_timeseries_group_by_campaign_authorizations_as_admin(
-        self, users, campaigns, timeseries_groups
-    ):
-        admin_user = users[0]
-        assert admin_user.is_admin
-        campaign_1 = campaigns[0]
-        campaign_2 = campaigns[1]
-        tsg_1 = timeseries_groups[0]
-
-        with CurrentUser(admin_user):
-            tgbc_1 = TimeseriesGroupByCampaign.new(
-                timeseries_group_id=tsg_1.id,
-                campaign_id=campaign_1.id,
-            )
-            db.session.add(tgbc_1)
-            db.session.commit()
-
-            tgbc = TimeseriesGroupByCampaign.get_by_id(tgbc_1.id)
-            assert tgbc.id == tgbc_1.id
-            tgbcs = list(TimeseriesGroupByCampaign.get())
-            assert len(tgbcs) == 1
-            assert tgbcs[0].id == tgbc_1.id
-            tgbc.update(campaign_id=campaign_2.id)
-            tgbc.delete()
-
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
-    @pytest.mark.usefixtures("users_by_campaigns")
-    def test_timeseries_group_by_campaign_authorizations_as_user(
-        self, users, campaigns, timeseries_groups_by_campaigns
-    ):
-        user_1 = users[1]
-        assert not user_1.is_admin
-        campaign_1 = campaigns[0]
-        campaign_2 = campaigns[1]
-        tgbc_1 = timeseries_groups_by_campaigns[0]
-        tgbc_2 = timeseries_groups_by_campaigns[1]
-
-        with CurrentUser(user_1):
-            with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesGroupByCampaign.new(
-                    timeseries_group_id=user_1.id,
-                    campaign_id=campaign_2.id,
-                )
-
-            tgbc = TimeseriesGroupByCampaign.get_by_id(tgbc_2.id)
-            tgbcs = list(TimeseriesGroupByCampaign.get())
-            assert len(tgbcs) == 1
-            assert tgbcs[0].id == tgbc_2.id
-            with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesGroupByCampaign.get_by_id(tgbc_1.id)
-            with pytest.raises(BEMServerAuthorizationError):
-                tgbc.update(campaign_id=campaign_1.id)
-            with pytest.raises(BEMServerAuthorizationError):
-                tgbc.delete()

--- a/tests/model/test_events.py
+++ b/tests/model/test_events.py
@@ -228,7 +228,6 @@ class TestEventModel:
         tse_list = list(Event.get(timestamp=timestamp_1))
         assert tse_list == []
 
-    @pytest.mark.usefixtures("users_by_campaigns")
     def test_event_authorizations_as_admin(
         self,
         users,
@@ -261,7 +260,8 @@ class TestEventModel:
             event_2.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_event_authorizations_as_user(self, users, campaigns, events):
         user_1 = users[1]
         assert not user_1.is_admin

--- a/tests/model/test_events.py
+++ b/tests/model/test_events.py
@@ -130,66 +130,6 @@ class TestEventCategoryModel:
 
 class TestEventModel:
     @pytest.mark.usefixtures("as_admin")
-    def test_event_list_by_state(self, campaigns):
-        campaign_1 = campaigns[0]
-
-        evts = Event.list_by_state()
-        assert evts == []
-        evts = Event.list_by_state(states=("NEW",))
-        assert evts == []
-        evts = Event.list_by_state(states=("ONGOING",))
-        assert evts == []
-        evts = Event.list_by_state(states=("CLOSED",))
-        assert evts == []
-
-        timestamp = dt.datetime(2020, 5, 1, tzinfo=dt.timezone.utc)
-
-        evt_1 = Event.new(
-            campaign_id=campaign_1.id,
-            timestamp=timestamp,
-            category="observation_missing",
-            source="src",
-            level="ERROR",
-            state="NEW",
-        )
-        evt_2 = Event.new(
-            campaign_id=campaign_1.id,
-            timestamp=timestamp,
-            category="observation_missing",
-            source="src",
-            level="ERROR",
-            state="NEW",
-        )
-        db.session.commit()
-
-        evts = Event.list_by_state()
-        assert evts == [(evt_1,), (evt_2,)]
-
-        evt_2.state = "CLOSED"
-        evt_3 = Event.new(
-            campaign_id=campaign_1.id,
-            timestamp=timestamp,
-            category="observation_missing",
-            source="src",
-            level="ERROR",
-            state="ONGOING",
-        )
-        db.session.commit()
-
-        # 2 of 3 events are in NEW or ONGOING state
-        evts = Event.list_by_state()
-        assert evts == [(evt_1,), (evt_3,)]
-        # one is NEW
-        evts = Event.list_by_state(states=("NEW",))
-        assert evts == [(evt_1,)]
-        # one is ONGOING
-        evts = Event.list_by_state(states=("ONGOING",))
-        assert evts == [(evt_3,)]
-        # one is closed
-        evts = Event.list_by_state(states=("CLOSED",))
-        assert evts == [(evt_2,)]
-
-    @pytest.mark.usefixtures("as_admin")
     def test_event_read_only_fields(self, campaigns):
         """Check campaign and timestamp can't be modified after commit
 

--- a/tests/model/test_timeseries.py
+++ b/tests/model/test_timeseries.py
@@ -84,7 +84,8 @@ class TestTimeseriesDataStateModel:
 
 
 class TestTimeseriesModel:
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_timeseries_filter_by_campaign_or_user(self, users, timeseries, campaigns):
         admin_user = users[0]
         assert admin_user.is_admin
@@ -132,7 +133,8 @@ class TestTimeseriesModel:
             ts.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_timeseries_authorizations_as_user(
         self,
         users,
@@ -192,7 +194,8 @@ class TestTimeseriesPropertyDataModel:
             tspd.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_timeseries_property_data_authorizations_as_user(
         self,
         users,
@@ -253,7 +256,8 @@ class TestTimeseriesByDataStateModel:
             tsbds.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_timeseries_by_data_state_authorizations_as_user(
         self,
         users,

--- a/tests/model/test_timeseries.py
+++ b/tests/model/test_timeseries.py
@@ -4,8 +4,6 @@ import pytest
 from bemserver_core.model import (
     TimeseriesProperty,
     TimeseriesDataState,
-    TimeseriesGroup,
-    TimeseriesGroupByUser,
     Timeseries,
     TimeseriesPropertyData,
     TimeseriesByDataState,
@@ -85,111 +83,8 @@ class TestTimeseriesDataStateModel:
                 ts_data_state_1.delete()
 
 
-class TestTimeseriesGroupModel:
-    def test_timeseries_group_authorizations_as_admin(self, users):
-        admin_user = users[0]
-        assert admin_user.is_admin
-
-        with CurrentUser(admin_user):
-            tsg_1 = TimeseriesGroup.new(
-                name="TS Group 1",
-            )
-            db.session.add(tsg_1)
-            db.session.commit()
-
-            timeseries_group = TimeseriesGroup.get_by_id(tsg_1.id)
-            assert timeseries_group.id == tsg_1.id
-            assert timeseries_group.name == tsg_1.name
-            timeseries_groups = list(TimeseriesGroup.get())
-            assert len(timeseries_groups) == 1
-            assert timeseries_groups[0].id == tsg_1.id
-            timeseries_group.update(name="Super timeseries 1")
-            timeseries_group.delete()
-            db.session.commit()
-
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
-    def test_timeseries_group_authorizations_as_user(self, users, timeseries_groups):
-        user_1 = users[1]
-        assert not user_1.is_admin
-        tsg_1 = timeseries_groups[0]
-        tsg_2 = timeseries_groups[1]
-
-        with CurrentUser(user_1):
-            with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesGroup.new(
-                    name="TS Group 1",
-                )
-
-            timeseries_group = TimeseriesGroup.get_by_id(tsg_2.id)
-            timeseries_group_list = list(TimeseriesGroup.get())
-            assert len(timeseries_group_list) == 1
-            assert timeseries_group_list[0].id == tsg_2.id
-            with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesGroup.get_by_id(tsg_1.id)
-            with pytest.raises(BEMServerAuthorizationError):
-                timeseries_group.update(name="Super timeseries 1")
-            with pytest.raises(BEMServerAuthorizationError):
-                timeseries_group.delete()
-
-
-class TestTimeseriesGroupByUserModel:
-    def test_timeseries_group_by_user_authorizations_as_admin(
-        self, users, timeseries_groups
-    ):
-        admin_user = users[0]
-        assert admin_user.is_admin
-        user_1 = users[1]
-        timeseries_group_1 = timeseries_groups[0]
-        timeseries_group_2 = timeseries_groups[1]
-
-        with CurrentUser(admin_user):
-            tgbu_1 = TimeseriesGroupByUser.new(
-                user_id=user_1.id,
-                timeseries_group_id=timeseries_group_1.id,
-            )
-            db.session.add(tgbu_1)
-            db.session.commit()
-
-            tgbu = TimeseriesGroupByUser.get_by_id(tgbu_1.id)
-            assert tgbu.id == tgbu_1.id
-            tgbus = list(TimeseriesGroupByUser.get())
-            assert len(tgbus) == 1
-            assert tgbus[0].id == tgbu_1.id
-            tgbu.update(timeseries_group_id=timeseries_group_2.id)
-            tgbu.delete()
-
-    def test_timeseries_group_by_user_authorizations_as_user(
-        self, users, timeseries_groups, timeseries_groups_by_users
-    ):
-        user_1 = users[1]
-        assert not user_1.is_admin
-        timeseries_group_1 = timeseries_groups[0]
-        timeseries_group_2 = timeseries_groups[1]
-        tgbu_1 = timeseries_groups_by_users[0]
-        tgbu_2 = timeseries_groups_by_users[1]
-
-        with CurrentUser(user_1):
-            with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesGroupByUser.new(
-                    user_id=user_1.id,
-                    timeseries_group_id=timeseries_group_2.id,
-                )
-
-            tgbu = TimeseriesGroupByUser.get_by_id(tgbu_2.id)
-            tgbus = list(TimeseriesGroupByUser.get())
-            assert len(tgbus) == 1
-            assert tgbus[0].id == tgbu_2.id
-            with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesGroupByUser.get_by_id(tgbu_1.id)
-            with pytest.raises(BEMServerAuthorizationError):
-                tgbu.update(timeseries_group_id=timeseries_group_1.id)
-            with pytest.raises(BEMServerAuthorizationError):
-                tgbu.delete()
-
-
 class TestTimeseriesModel:
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
-    @pytest.mark.usefixtures("timeseries_groups_by_campaigns")
+    @pytest.mark.usefixtures("users_by_campaigns")
     def test_timeseries_filter_by_campaign_or_user(self, users, timeseries, campaigns):
         admin_user = users[0]
         assert admin_user.is_admin
@@ -214,15 +109,15 @@ class TestTimeseriesModel:
             assert len(ts_l) == 1
             assert ts_l[0] == ts_2
 
-    def test_timeseries_authorizations_as_admin(self, users, timeseries_groups):
+    def test_timeseries_authorizations_as_admin(self, users, campaigns):
         admin_user = users[0]
         assert admin_user.is_admin
-        tsg_1 = timeseries_groups[0]
+        campaign_1 = campaigns[0]
 
         with CurrentUser(admin_user):
             ts_1 = Timeseries.new(
                 name="Timeseries 1",
-                group_id=tsg_1.id,
+                campaign_id=campaign_1.id,
             )
             db.session.add(ts_1)
             db.session.commit()
@@ -237,21 +132,24 @@ class TestTimeseriesModel:
             ts.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    @pytest.mark.usefixtures("users_by_campaigns")
     def test_timeseries_authorizations_as_user(
-        self, users, timeseries, timeseries_groups
+        self,
+        users,
+        timeseries,
+        campaigns,
     ):
         user_1 = users[1]
         assert not user_1.is_admin
         ts_1 = timeseries[0]
         ts_2 = timeseries[1]
-        tsg_1 = timeseries_groups[0]
+        campaign_1 = campaigns[0]
 
         with CurrentUser(user_1):
             with pytest.raises(BEMServerAuthorizationError):
                 Timeseries.new(
                     name="Timeseries 1",
-                    group_id=tsg_1.id,
+                    campaign_id=campaign_1.id,
                 )
 
             timeseries = Timeseries.get_by_id(ts_2.id)
@@ -294,7 +192,7 @@ class TestTimeseriesPropertyDataModel:
             tspd.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    @pytest.mark.usefixtures("users_by_campaigns")
     def test_timeseries_property_data_authorizations_as_user(
         self,
         users,
@@ -355,9 +253,12 @@ class TestTimeseriesByDataStateModel:
             tsbds.delete()
             db.session.commit()
 
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    @pytest.mark.usefixtures("users_by_campaigns")
     def test_timeseries_by_data_state_authorizations_as_user(
-        self, users, timeseries, timeseries_by_data_states
+        self,
+        users,
+        timeseries,
+        timeseries_by_data_states,
     ):
         user_1 = users[1]
         assert not user_1.is_admin
@@ -381,7 +282,7 @@ class TestTimeseriesByDataStateModel:
             )
             db.session.commit()
 
-            # Not member of group
+            # Not member of campaign
             with pytest.raises(BEMServerAuthorizationError):
                 TimeseriesByDataState.new(
                     timeseries_id=ts_1.id,

--- a/tests/test_csv_io.py
+++ b/tests/test_csv_io.py
@@ -79,7 +79,8 @@ class TestTimeseriesCSVIO:
         assert data == expected
 
     @pytest.mark.parametrize("timeseries", (3,), indirect=True)
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_timeseries_csv_io_import_csv_as_user(self, users, timeseries):
         user_1 = users[1]
         assert not user_1.is_admin
@@ -212,7 +213,8 @@ class TestTimeseriesCSVIO:
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_timeseries_csv_io_export_csv_as_user(
         self, users, timeseries, timeseries_by_data_states
     ):
@@ -420,7 +422,8 @@ class TestTimeseriesCSVIO:
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
-    @pytest.mark.usefixtures("users_by_campaigns")
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
     def test_timeseries_csv_io_export_csv_bucket_as_user(
         self, users, timeseries, timeseries_by_data_states
     ):

--- a/tests/test_csv_io.py
+++ b/tests/test_csv_io.py
@@ -80,7 +80,7 @@ class TestTimeseriesCSVIO:
 
     @pytest.mark.parametrize("timeseries", (3,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
-    @pytest.mark.usefixtures("user_groups_by_campaigns")
+    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
     def test_timeseries_csv_io_import_csv_as_user(self, users, timeseries):
         user_1 = users[1]
         assert not user_1.is_admin
@@ -214,7 +214,7 @@ class TestTimeseriesCSVIO:
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
-    @pytest.mark.usefixtures("user_groups_by_campaigns")
+    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
     def test_timeseries_csv_io_export_csv_as_user(
         self, users, timeseries, timeseries_by_data_states
     ):
@@ -423,7 +423,7 @@ class TestTimeseriesCSVIO:
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
-    @pytest.mark.usefixtures("user_groups_by_campaigns")
+    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
     def test_timeseries_csv_io_export_csv_bucket_as_user(
         self, users, timeseries, timeseries_by_data_states
     ):

--- a/tests/test_csv_io.py
+++ b/tests/test_csv_io.py
@@ -79,7 +79,7 @@ class TestTimeseriesCSVIO:
         assert data == expected
 
     @pytest.mark.parametrize("timeseries", (3,), indirect=True)
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    @pytest.mark.usefixtures("users_by_campaigns")
     def test_timeseries_csv_io_import_csv_as_user(self, users, timeseries):
         user_1 = users[1]
         assert not user_1.is_admin
@@ -155,7 +155,6 @@ class TestTimeseriesCSVIO:
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
     def test_timeseries_csv_io_export_csv_as_admin(
         self, users, timeseries, timeseries_by_data_states
     ):
@@ -213,7 +212,7 @@ class TestTimeseriesCSVIO:
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    @pytest.mark.usefixtures("users_by_campaigns")
     def test_timeseries_csv_io_export_csv_as_user(
         self, users, timeseries, timeseries_by_data_states
     ):
@@ -284,7 +283,6 @@ class TestTimeseriesCSVIO:
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
     def test_timeseries_csv_io_export_csv_bucket_as_admin(
         self, users, timeseries, timeseries_by_data_states
     ):
@@ -422,7 +420,7 @@ class TestTimeseriesCSVIO:
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("timeseries_by_data_states", (5,), indirect=True)
-    @pytest.mark.usefixtures("timeseries_groups_by_users")
+    @pytest.mark.usefixtures("users_by_campaigns")
     def test_timeseries_csv_io_export_csv_bucket_as_user(
         self, users, timeseries, timeseries_by_data_states
     ):


### PR DESCRIPTION
Remove event channels and timeseries groups. Replace them with a common concept: campaign scope.

Add user group concept.