### PR TITLE
Tox: use install.txt for the tests

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -14,11 +14,11 @@ cffi==1.15.0
     #   oso
 greenlet==1.1.2
     # via sqlalchemy
-numpy==1.22.3
+numpy==1.21.5
     # via pandas
 oso==0.26.0
     # via bemserver-core (setup.py)
-pandas==1.4.1
+pandas==1.3.5
     # via bemserver-core (setup.py)
 passlib==1.7.4
     # via bemserver-core (setup.py)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = True
 [testenv]
 deps =
     -r requirements/tests.txt
+    -r requirements/install.txt
 commands =
     pytest -p no:logging --cov={envsitepackagesdir}/bemserver_core --cov-branch --cov-report=term-missing
 


### PR DESCRIPTION
Before this change, install.txt is ignored by tox in the tests and we test on latest versions.

Pinning numpy / pandas for the tests while we still support Python 3.7.

numpy==1.21.5
pandas==1.3.5