### PR TITLE
Set Session.autoflush = True

### DIFF
--- a/bemserver_core/database.py
+++ b/bemserver_core/database.py
@@ -96,7 +96,7 @@ class Base:
         db.session.delete(self)
 
 
-SESSION_FACTORY = sessionmaker(autocommit=False, autoflush=False)
+SESSION_FACTORY = sessionmaker()
 DB_SESSION = scoped_session(SESSION_FACTORY)
 Base = declarative_base(cls=Base)
 

--- a/tests/model/test_campaigns.py
+++ b/tests/model/test_campaigns.py
@@ -171,7 +171,7 @@ class TestCampaignScopeModel:
 
     @pytest.mark.usefixtures("as_admin")
     def test_campaign_scope_read_only_fields(self, campaigns):
-        """Check campaign can't be modified after commit
+        """Check campaign can't be modified
 
         Also check the getter/setter don't get in the way when querying.
         This is kind of a "framework test".
@@ -183,15 +183,14 @@ class TestCampaignScopeModel:
             name="Campaign scope 1",
             campaign_id=campaign_1.id,
         )
-        cs_1.update(campaign_id=campaign_2.id)
-        db.session.commit()
+        db.session.flush()
 
         with pytest.raises(AttributeError):
             cs_1.update(campaign_id=campaign_2.id)
 
-        cs_list = list(CampaignScope.get(campaign_id=2))
-        assert cs_list == [cs_1]
         cs_list = list(CampaignScope.get(campaign_id=1))
+        assert cs_list == [cs_1]
+        cs_list = list(CampaignScope.get(campaign_id=2))
         assert cs_list == []
 
     def test_campaign_scope_authorizations_as_admin(self, users, campaigns):

--- a/tests/model/test_events.py
+++ b/tests/model/test_events.py
@@ -131,7 +131,7 @@ class TestEventCategoryModel:
 class TestEventModel:
     @pytest.mark.usefixtures("as_admin")
     def test_event_read_only_fields(self, campaign_scopes):
-        """Check campaign_scope and timestamp can't be modified after commit
+        """Check campaign_scope and timestamp can't be modified
 
         Also check the getter/setter don't get in the way when querying.
         This is kind of a "framework test".
@@ -150,22 +150,20 @@ class TestEventModel:
             level="ERROR",
             state="NEW",
         )
-        evt_1.update(timestamp=timestamp_2)
-        evt_1.update(campaign_scope_id=campaign_scope_2.id)
-        db.session.commit()
+        db.session.flush()
 
         with pytest.raises(AttributeError):
             evt_1.update(timestamp=timestamp_1)
         with pytest.raises(AttributeError):
             evt_1.update(campaign_scope_id=campaign_scope_2.id)
 
-        tse_list = list(Event.get(campaign_scope_id=2))
-        assert tse_list == [evt_1]
         tse_list = list(Event.get(campaign_scope_id=1))
-        assert tse_list == []
-        tse_list = list(Event.get(timestamp=timestamp_2))
         assert tse_list == [evt_1]
+        tse_list = list(Event.get(campaign_scope_id=2))
+        assert tse_list == []
         tse_list = list(Event.get(timestamp=timestamp_1))
+        assert tse_list == [evt_1]
+        tse_list = list(Event.get(timestamp=timestamp_2))
         assert tse_list == []
 
     def test_event_authorizations_as_admin(

--- a/tests/model/test_timeseries.py
+++ b/tests/model/test_timeseries.py
@@ -162,7 +162,7 @@ class TestTimeseriesModel:
 
     @pytest.mark.usefixtures("as_admin")
     def test_timeseries_read_only_fields(self, campaigns, campaign_scopes):
-        """Check campaign and campaign_scope can't be modified after commit
+        """Check campaign and campaign_scope can't be modified
 
         Also check the getter/setter don't get in the way when querying.
         This is kind of a "framework test".
@@ -177,22 +177,20 @@ class TestTimeseriesModel:
             campaign_id=campaign_1.id,
             campaign_scope_id=campaign_scope_1.id,
         )
-        ts_1.update(campaign_id=campaign_2.id)
-        ts_1.update(campaign_scope_id=campaign_scope_2.id)
-        db.session.commit()
+        db.session.flush()
 
         with pytest.raises(AttributeError):
             ts_1.update(campaign_id=campaign_2.id)
         with pytest.raises(AttributeError):
             ts_1.update(campaign_scope_id=campaign_scope_2.id)
 
-        ts_list = list(Timeseries.get(campaign_id=2))
-        assert ts_list == [ts_1]
         ts_list = list(Timeseries.get(campaign_id=1))
-        assert ts_list == []
-        ts_list = list(Timeseries.get(campaign_scope_id=2))
         assert ts_list == [ts_1]
+        ts_list = list(Timeseries.get(campaign_id=2))
+        assert ts_list == []
         ts_list = list(Timeseries.get(campaign_scope_id=1))
+        assert ts_list == [ts_1]
+        ts_list = list(Timeseries.get(campaign_scope_id=2))
         assert ts_list == []
 
     @pytest.mark.usefixtures("users_by_user_groups")

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -31,7 +31,6 @@ class TestAuthMixin:
         db.session.add(mes_1)
         db.session.add(mes_2)
         db.session.add(mes_3)
-        db.session.commit()
 
         ret = Test.get(sort=["severity"]).all()
         assert ret == [mes_1, mes_3, mes_2]
@@ -49,7 +48,6 @@ class TestAuthMixin:
         db.session.add(mes_4)
         db.session.add(mes_5)
         db.session.add(mes_6)
-        db.session.commit()
 
         ret = Test.get(sort=["-severity", "title"]).all()
         assert ret == [mes_5, mes_2, mes_3, mes_6, mes_4, mes_1]
@@ -73,7 +71,6 @@ class TestAuthMixin:
         db.session.add(mes_1)
         db.session.add(mes_2)
         db.session.add(mes_3)
-        db.session.commit()
 
         ret = Test.get(note_min=12).all()
         assert ret == [mes_2, mes_3]

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -14,7 +14,7 @@ class TestAuthMixin:
     def test_auth_mixin_sort(self):
         """Check AuthMixin doesn't break database sort feature"""
 
-        class Test(Base, AuthMixin):
+        class TestAuthMixinSort(Base, AuthMixin):
             __tablename__ = "test_auth_mixin_sort"
 
             id = sqla.Column(sqla.Integer, primary_key=True)
@@ -22,6 +22,8 @@ class TestAuthMixin:
             severity = sqla.Column(
                 sqla.Enum("Low", "High", "Critical", name="test_auth_mixin_severity")
             )
+
+        Test = TestAuthMixinSort
 
         Test.__table__.create(bind=db.engine)
 
@@ -56,12 +58,14 @@ class TestAuthMixin:
     def test_auth_mixin_min_max(self):
         """Check AuthMixin doesn't break database min/max feature"""
 
-        class Test(Base, AuthMixin):
+        class TestAuthMixinMinMax(Base, AuthMixin):
             __tablename__ = "test_auth_mixin_min_max"
 
             id = sqla.Column(sqla.Integer, primary_key=True)
             note = sqla.Column(sqla.Float())
             date = sqla.Column(sqla.DateTime(timezone=True))
+
+        Test = TestAuthMixinMinMax
 
         Test.__table__.create(bind=db.engine)
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -57,7 +57,6 @@ class TestDatabase:
         db.session.add(mes_1)
         db.session.add(mes_2)
         db.session.add(mes_3)
-        db.session.commit()
 
         ret = Test.get(sort=["severity"]).all()
         assert ret == [mes_1, mes_3, mes_2]
@@ -75,7 +74,6 @@ class TestDatabase:
         db.session.add(mes_4)
         db.session.add(mes_5)
         db.session.add(mes_6)
-        db.session.commit()
 
         ret = Test.get(sort=["-severity", "title"]).all()
         assert ret == [mes_5, mes_2, mes_3, mes_6, mes_4, mes_1]
@@ -99,7 +97,6 @@ class TestDatabase:
         db.session.add(mes_1)
         db.session.add(mes_2)
         db.session.add(mes_3)
-        db.session.commit()
 
         ret = Test.get(note_min=12).all()
         assert ret == [mes_2, mes_3]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -13,12 +13,14 @@ class TestDatabase:
     def test_database_base_update(self):
         """Test update method of custom Base class"""
 
-        class Test(Base):
+        class TestDatabaseBaseUpdate(Base):
             __tablename__ = "test_database_base_update"
 
             id = sqla.Column(sqla.Integer, primary_key=True)
             test_1 = sqla.Column(sqla.String(80), nullable=True)
             test_2 = sqla.Column(sqla.String(80), nullable=False)
+
+        Test = TestDatabaseBaseUpdate
 
         test = Test(test_1="test_1", test_2="test_2")
         assert test.test_1 == "test_1"
@@ -37,10 +39,10 @@ class TestDatabase:
         assert test.test_2 is None
 
     @pytest.mark.usefixtures("database")
-    def test_database_sort(self):
+    def test_database_base_sort(self):
         """Test sort feature"""
 
-        class Test(Base):
+        class TestDatabaseBaseSort(Base):
             __tablename__ = "test_database_sort"
 
             id = sqla.Column(sqla.Integer, primary_key=True)
@@ -48,6 +50,8 @@ class TestDatabase:
             severity = sqla.Column(
                 sqla.Enum("Low", "High", "Critical", name="test_db_severity")
             )
+
+        Test = TestDatabaseBaseSort
 
         Test.__table__.create(bind=db.engine)
 
@@ -79,15 +83,17 @@ class TestDatabase:
         assert ret == [mes_5, mes_2, mes_3, mes_6, mes_4, mes_1]
 
     @pytest.mark.usefixtures("database")
-    def test_database_min_max(self):
+    def test_database_base_min_max(self):
         """Test min / max feature"""
 
-        class Test(Base):
+        class TestDatabaseBaseMinMax(Base):
             __tablename__ = "test_database_min_max"
 
             id = sqla.Column(sqla.Integer, primary_key=True)
             note = sqla.Column(sqla.Float())
             date = sqla.Column(sqla.DateTime(timezone=True))
+
+        Test = TestDatabaseBaseMinMax
 
         Test.__table__.create(bind=db.engine)
 


### PR DESCRIPTION
There is no need to override the default connection parameters.

Also fix unrelated SQLAlchemy warnings in tests.