### PR TITLE
Refactor TimeseriesDataIO

### DIFF
--- a/bemserver_core/database.py
+++ b/bemserver_core/database.py
@@ -153,7 +153,8 @@ class DBConnection:
             db_url,
             # Set UTC for all connections
             connect_args={"options": "-c timezone=utc"},
-            future=True,
+            # https://github.com/pandas-dev/pandas/issues/40686
+            # future=True,
         )
         SESSION_FACTORY.configure(bind=self.engine)
 

--- a/bemserver_core/database.py
+++ b/bemserver_core/database.py
@@ -153,8 +153,7 @@ class DBConnection:
             db_url,
             # Set UTC for all connections
             connect_args={"options": "-c timezone=utc"},
-            # https://github.com/pandas-dev/pandas/issues/40686
-            # future=True,
+            future=True,
         )
         SESSION_FACTORY.configure(bind=self.engine)
 

--- a/bemserver_core/exceptions.py
+++ b/bemserver_core/exceptions.py
@@ -29,10 +29,6 @@ class TimeseriesDataIOError(BEMServerCoreIOError):
     """Timeseries data IO error"""
 
 
-class TimeseriesDataIOWriteError(TimeseriesDataIOError):
-    """Timeseries data IO write error"""
-
-
 class TimeseriesDataIOInvalidAggregationError(TimeseriesDataIOError):
     """Timeseries data IO invalid aggregation error"""
 

--- a/bemserver_core/exceptions.py
+++ b/bemserver_core/exceptions.py
@@ -29,10 +29,6 @@ class TimeseriesDataIOError(BEMServerCoreIOError):
     """Timeseries data IO error"""
 
 
-class TimeseriesDataIOUnknownDataStateError(TimeseriesDataIOError):
-    """Timeseries data IO unknown data state error"""
-
-
 class TimeseriesDataIOWriteError(TimeseriesDataIOError):
     """Timeseries data IO write error"""
 

--- a/bemserver_core/exceptions.py
+++ b/bemserver_core/exceptions.py
@@ -5,6 +5,10 @@ class BEMServerCoreError(Exception):
     """Base BEMServer Core exception"""
 
 
+class TimeseriesNotFoundError(BEMServerCoreError):
+    """Timeseries not found"""
+
+
 class BEMServerCoreIOError(BEMServerCoreError):
     """Base IO error"""
 
@@ -27,10 +31,6 @@ class TimeseriesDataIOError(BEMServerCoreIOError):
 
 class TimeseriesDataIOUnknownDataStateError(TimeseriesDataIOError):
     """Timeseries data IO unknown data state error"""
-
-
-class TimeseriesDataIOUnknownTimeseriesError(TimeseriesDataIOError):
-    """Timeseries data IO unknown timeseries error"""
 
 
 class TimeseriesDataIOWriteError(TimeseriesDataIOError):

--- a/bemserver_core/input_output/__init__.py
+++ b/bemserver_core/input_output/__init__.py
@@ -1,4 +1,4 @@
 """I/O"""
-from .timeseries_data_io import tsdcsvio  # noqa
+from .timeseries_data_io import tsdio, tsdcsvio  # noqa
 from .sites_io import sites_csv_io  # noqa
 from .timeseries_io import timeseries_csv_io  # noqa

--- a/bemserver_core/input_output/base.py
+++ b/bemserver_core/input_output/base.py
@@ -7,14 +7,6 @@ from bemserver_core import model
 from bemserver_core.exceptions import BEMServerCoreIOError, BEMServerCoreCSVIOError
 
 
-def enforce_iterator(csv_file):
-    # If input is not a text stream, then it is a plain string
-    # Make it an iterator
-    if not isinstance(csv_file, io.TextIOBase):
-        csv_file = csv_file.splitlines()
-    return csv_file
-
-
 class BaseIO:
     """Base class for IO classes"""
 
@@ -86,13 +78,15 @@ class BaseCSVIO(BaseIO):
     """Base class for CSV IO classes"""
 
     @staticmethod
-    def csv_reader(csv_file):
-        csv_file = enforce_iterator(csv_file)
-        return csv.reader(csv_file)
+    def _enforce_iterator(csv_file):
+        # If input is not a text stream, then it is a plain string
+        if not isinstance(csv_file, io.TextIOBase):
+            csv_file = io.StringIO(csv_file)
+        return csv_file
 
-    @staticmethod
-    def csv_dict_reader(csv_file):
-        csv_file = enforce_iterator(csv_file)
+    @classmethod
+    def csv_dict_reader(cls, csv_file):
+        csv_file = cls._enforce_iterator(csv_file)
         return csv.DictReader(csv_file)
 
     @classmethod

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -163,7 +163,7 @@ class TimeseriesDataIO:
         :param string col_label: Timeseries attribute to use for column header.
             Should be "id" or "name". Default: "id".
 
-        Returns csv as a string.
+        Returns a dataframe.
         """
         if aggregation not in AGGREGATION_FUNCTIONS:
             raise TimeseriesDataIOInvalidAggregationError("Invalid aggregation method")

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -72,13 +72,15 @@ class TimeseriesDataIO:
             var_name="timeseries_by_data_state_id",
             ignore_index=False,
         )
+        data_dict = data_df.reset_index().to_dict(orient="records")
 
-        data_df.to_sql(
-            TimeseriesData.__tablename__,
-            db.session.connection(),
-            if_exists="append",
-            index=True,
+        query = (
+            sqla.dialects.postgresql.insert(TimeseriesData)
+            .values(data_dict)
+            .on_conflict_do_nothing()
         )
+        db.session.execute(query)
+        db.session.commit()
 
     @staticmethod
     def _fill_missing_columns(data_df, ts_l, attr):

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -371,4 +371,5 @@ class TimeseriesDataCSVIO(TimeseriesDataIO, BaseCSVIO):
         return data_df.to_csv(date_format="%Y-%m-%dT%H:%M:%S%z")
 
 
+tsdio = TimeseriesDataIO()
 tsdcsvio = TimeseriesDataCSVIO()

--- a/bemserver_core/model/timeseries.py
+++ b/bemserver_core/model/timeseries.py
@@ -12,6 +12,7 @@ from bemserver_core.model.campaigns import (
     UserGroupByCampaignScope,
 )
 from bemserver_core.model.sites import Site, Building, Storey, Space, Zone
+from bemserver_core.exceptions import TimeseriesNotFoundError
 
 
 class TimeseriesProperty(AuthMixin, Base):
@@ -111,7 +112,7 @@ class Timeseries(AuthMixin, Base):
         storey_id=None,
         space_id=None,
         zone_id=None,
-        **kwargs
+        **kwargs,
     ):
         if "campaign_id" in kwargs:
             Campaign.get_by_id(kwargs["campaign_id"])
@@ -254,6 +255,33 @@ class Timeseries(AuthMixin, Base):
         :param str name: Timeseries name
         """
         return Timeseries.get(name=name, campaign_id=campaign.id).first()
+
+    @classmethod
+    def get_many_by_id(cls, timeseries):
+        """Get a list of timeseries by ID
+
+        :param list timeseries: List of timeseries IDs
+        """
+        ts_d = {col: Timeseries.get_by_id(col) for col in timeseries}
+        if None in ts_d.values():
+            raise TimeseriesNotFoundError(
+                f"Unknown timeseries: {[k for k in ts_d.keys() if ts_d[k] is None]}"
+            )
+        return ts_d.values()
+
+    @classmethod
+    def get_many_by_name(cls, campaign, timeseries):
+        """Get a list of timeseries by name for a given campaign
+
+        :param list timeseries: List of timeseries names
+        :param Campaign campaign: Campaign
+        """
+        ts_d = {col: Timeseries.get_by_name(campaign, col) for col in timeseries}
+        if None in ts_d.values():
+            raise TimeseriesNotFoundError(
+                f"Unknown timeseries: {[k for k in ts_d.keys() if ts_d[k] is None]}"
+            )
+        return ts_d.values()
 
 
 class TimeseriesPropertyData(AuthMixin, Base):

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -154,13 +154,16 @@ class TestTimeseriesDataCSVIO:
     @pytest.mark.parametrize(
         "file_error",
         (
+            # Empty file
             ("", TimeseriesDataCSVIOError),
-            ("Dummy,\n", TimeseriesDataCSVIOError),
+            # Empty TS name
+            ("Datetime,1,\n", TimeseriesDataCSVIOError),
+            # Unknown TS
             ("Datetime,1324564", TimeseriesNotFoundError),
         ),
     )
     @pytest.mark.parametrize("for_campaign", (True, False))
-    def test_timeseries_data_io_import_error(
+    def test_timeseries_data_io_import_csv_file_error(
         self, users, campaigns, for_campaign, file_error
     ):
         admin_user = users[0]
@@ -178,15 +181,13 @@ class TestTimeseriesDataCSVIO:
     @pytest.mark.parametrize(
         "row",
         (
-            "2020-01-01T00:00:00+00:00",
-            "2020-01-01T00:00:00+00:00,",
             "2020-01-01T00:00:00+00:00,a",
             "dummy,1",
         ),
     )
     @pytest.mark.usefixtures("timeseries")
     @pytest.mark.parametrize("for_campaign", (True, False))
-    def test_timeseries_data_io_import_csv_error(
+    def test_timeseries_data_io_import_csv_row_error(
         self, users, campaigns, for_campaign, row
     ):
         admin_user = users[0]

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -2,6 +2,9 @@
 import io
 import datetime as dt
 
+import pandas as pd
+import numpy as np
+
 import pytest
 
 from bemserver_core.model import (
@@ -10,6 +13,7 @@ from bemserver_core.model import (
     TimeseriesByDataState,
 )
 from bemserver_core.input_output import tsdcsvio
+from bemserver_core.input_output.timeseries_data_io import TimeseriesDataIO
 from bemserver_core.database import db
 from bemserver_core.authorization import CurrentUser, OpenBar
 from bemserver_core.exceptions import (
@@ -18,6 +22,719 @@ from bemserver_core.exceptions import (
     TimeseriesDataCSVIOError,
     TimeseriesNotFoundError,
 )
+
+
+class TestTimeseriesDataIO:
+    @pytest.mark.parametrize("timeseries", (3,), indirect=True)
+    @pytest.mark.parametrize("for_campaign", (True, False))
+    def test_timeseries_data_io_set_timeseries_data_as_admin(
+        self, users, campaigns, timeseries, for_campaign
+    ):
+        admin_user = users[0]
+        assert admin_user.is_admin
+        ts_0 = timeseries[0]
+        ts_2 = timeseries[2]
+        campaign = campaigns[0] if for_campaign else None
+
+        assert not db.session.query(TimeseriesByDataState).all()
+        assert not db.session.query(TimeseriesData).all()
+
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+
+        index = pd.DatetimeIndex(
+            [
+                "2020-01-01T00:00:00+00:00",
+                "2020-01-01T01:00:00+00:00",
+                "2020-01-01T02:00:00+00:00",
+                "2020-01-01T03:00:00+00:00",
+            ],
+            name="timestamp",
+        )
+        val_0 = [0, 1, 2, 3]
+        val_2 = [10, 11, 12, 13]
+        data_df = pd.DataFrame(
+            {
+                ts_0.name if for_campaign else ts_0.id: val_0,
+                ts_2.name if for_campaign else ts_2.id: val_2,
+            },
+            index=index,
+        )
+
+        with CurrentUser(admin_user):
+            TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+
+        # Check TSBDS are correctly auto-created
+        tsbds_l = (
+            db.session.query(TimeseriesByDataState)
+            .order_by(TimeseriesByDataState.id)
+            .all()
+        )
+        assert all(tsbds.data_state_id == ds_1.id for tsbds in tsbds_l)
+        tsbds_0 = tsbds_l[0]
+        tsbds_2 = tsbds_l[1]
+        assert tsbds_0.timeseries == ts_0
+        assert tsbds_2.timeseries == ts_2
+
+        # Check timeseries data is written
+        data = (
+            db.session.query(
+                TimeseriesData.timestamp,
+                TimeseriesData.timeseries_by_data_state_id,
+                TimeseriesData.value,
+            )
+            .order_by(
+                TimeseriesData.timeseries_by_data_state_id,
+                TimeseriesData.timestamp,
+            )
+            .all()
+        )
+
+        timestamps = [
+            dt.datetime(2020, 1, 1, i, tzinfo=dt.timezone.utc) for i in range(4)
+        ]
+
+        expected = [
+            (timestamp, tsbds_0.id, float(idx))
+            for idx, timestamp in enumerate(timestamps)
+        ] + [
+            (timestamp, tsbds_2.id, float(idx) + 10)
+            for idx, timestamp in enumerate(timestamps)
+        ]
+
+        assert data == expected
+
+    @pytest.mark.parametrize("timeseries", (3,), indirect=True)
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
+    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
+    @pytest.mark.parametrize("for_campaign", (True, False))
+    def test_timeseries_data_io_set_timeseries_data_as_user(
+        self, users, timeseries, campaigns, for_campaign
+    ):
+        user_1 = users[1]
+        assert not user_1.is_admin
+        ts_0 = timeseries[0]
+        ts_1 = timeseries[1]
+        ts_2 = timeseries[2]
+
+        assert not db.session.query(TimeseriesData).all()
+
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+
+        index = pd.DatetimeIndex(
+            [
+                "2020-01-01T00:00:00+00:00",
+                "2020-01-01T01:00:00+00:00",
+                "2020-01-01T02:00:00+00:00",
+                "2020-01-01T03:00:00+00:00",
+            ],
+            name="timestamp",
+        )
+        val_0 = [0, 1, 2, 3]
+        val_2 = [10, 11, 12, 13]
+
+        data_df = pd.DataFrame(
+            {
+                ts_0.name if for_campaign else ts_0.id: val_0,
+                ts_2.name if for_campaign else ts_2.id: val_2,
+            },
+            index=index,
+        )
+
+        if for_campaign:
+            campaign = campaigns[0]
+        else:
+            campaign = None
+
+        with CurrentUser(user_1):
+            with pytest.raises(BEMServerAuthorizationError):
+                TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+
+        data_df = pd.DataFrame(
+            {
+                ts_1.name if for_campaign else ts_1.id: val_0,
+            },
+            index=index,
+        )
+
+        if for_campaign:
+            campaign = campaigns[1]
+        else:
+            campaign = None
+
+        with CurrentUser(user_1):
+            TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+
+    @pytest.mark.parametrize("for_campaign", (True, False))
+    def test_timeseries_data_io_import_set_timeseries_data_timeseries_error(
+        self, users, campaigns, for_campaign
+    ):
+        admin_user = users[0]
+        assert admin_user.is_admin
+        campaign = campaigns[0] if for_campaign else None
+
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+
+        index = pd.DatetimeIndex(
+            [
+                "2020-01-01T00:00:00+00:00",
+                "2020-01-01T01:00:00+00:00",
+                "2020-01-01T02:00:00+00:00",
+                "2020-01-01T03:00:00+00:00",
+            ],
+            name="timestamp",
+        )
+        val_0 = [0, 1, 2, 3]
+
+        data_df = pd.DataFrame(
+            {"Timeseries 0" if for_campaign else 1: val_0},
+            index=index,
+        )
+
+        with CurrentUser(admin_user):
+            with pytest.raises(TimeseriesNotFoundError):
+                TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+
+    @pytest.mark.parametrize("timeseries", (5,), indirect=True)
+    @pytest.mark.parametrize("col_label", ("id", "name"))
+    def test_timeseries_data_io_get_timeseries_data_as_admin(
+        self, users, timeseries, col_label
+    ):
+        admin_user = users[0]
+        assert admin_user.is_admin
+        ts_0 = timeseries[0]
+        ts_2 = timeseries[2]
+        ts_4 = timeseries[4]
+
+        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+        end_dt = start_dt + dt.timedelta(hours=3)
+
+        # Create DB data
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+            tsbds_0 = ts_0.get_timeseries_by_data_state(ds_1)
+            tsbds_4 = ts_4.get_timeseries_by_data_state(ds_1)
+            for i in range(3):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_0.id,
+                        value=i,
+                    )
+                )
+            for i in range(2):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_4.id,
+                        value=10 + 2 * i,
+                    )
+                )
+            db.session.commit()
+
+        with CurrentUser(admin_user):
+
+            ts_l = (ts_0, ts_2, ts_4)
+            data_df = TimeseriesDataIO().get_timeseries_data(
+                start_dt, end_dt, ts_l, ds_1, col_label
+            )
+
+        index = pd.DatetimeIndex(
+            [
+                "2020-01-01T00:00:00+00:00",
+                "2020-01-01T01:00:00+00:00",
+                "2020-01-01T02:00:00+00:00",
+            ],
+            name="timestamp",
+        )
+        val_0 = [0.0, 1.0, 2.0]
+        val_2 = [np.nan, np.nan, np.nan]
+        val_4 = [10.0, 12.0, np.nan]
+        expected_data_df = pd.DataFrame(
+            {
+                ts_0.name if col_label == "name" else ts_0.id: val_0,
+                ts_2.name if col_label == "name" else ts_2.id: val_2,
+                ts_4.name if col_label == "name" else ts_4.id: val_4,
+            },
+            index=index,
+        )
+        assert data_df.equals(expected_data_df)
+
+    @pytest.mark.parametrize("timeseries", (5,), indirect=True)
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
+    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
+    @pytest.mark.parametrize("col_label", ("id", "name"))
+    def test_timeseries_data_io_get_timeseries_data_as_user(
+        self, users, timeseries, col_label
+    ):
+        user_1 = users[1]
+        assert not user_1.is_admin
+        ts_0 = timeseries[0]
+        ts_1 = timeseries[1]
+        ts_2 = timeseries[2]
+        ts_3 = timeseries[3]
+        ts_4 = timeseries[4]
+
+        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+        end_dt = start_dt + dt.timedelta(hours=3)
+
+        # Create DB data
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+            tsbds_1 = ts_1.get_timeseries_by_data_state(ds_1)
+            tsbds_3 = ts_3.get_timeseries_by_data_state(ds_1)
+            for i in range(3):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_1.id,
+                        value=i,
+                    )
+                )
+            for i in range(2):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_3.id,
+                        value=10 + 2 * i,
+                    )
+                )
+            db.session.commit()
+
+        with CurrentUser(user_1):
+
+            ts_l = (ts_0, ts_2, ts_4)
+
+            with pytest.raises(BEMServerAuthorizationError):
+                TimeseriesDataIO().get_timeseries_data(
+                    start_dt, end_dt, ts_l, ds_1, col_label=col_label
+                )
+
+            ts_l = (ts_1, ts_3)
+            data_df = TimeseriesDataIO().get_timeseries_data(
+                start_dt, end_dt, ts_l, ds_1, col_label=col_label
+            )
+
+        index = pd.DatetimeIndex(
+            [
+                "2020-01-01T00:00:00+00:00",
+                "2020-01-01T01:00:00+00:00",
+                "2020-01-01T02:00:00+00:00",
+            ],
+            name="timestamp",
+        )
+        val_1 = [0.0, 1.0, 2.0]
+        val_3 = [10.0, 12.0, np.nan]
+        expected_data_df = pd.DataFrame(
+            {
+                ts_1.name if col_label == "name" else ts_1.id: val_1,
+                ts_3.name if col_label == "name" else ts_3.id: val_3,
+            },
+            index=index,
+        )
+        assert data_df.equals(expected_data_df)
+
+    @pytest.mark.parametrize("timeseries", (5,), indirect=True)
+    @pytest.mark.parametrize("col_label", ("id", "name"))
+    def test_timeseries_data_io_get_timeseries_buckets_data_as_admin(
+        self, users, timeseries, col_label
+    ):
+        admin_user = users[0]
+        assert admin_user.is_admin
+        ts_0 = timeseries[0]
+        ts_2 = timeseries[2]
+        ts_4 = timeseries[4]
+
+        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+        end_dt = start_dt + dt.timedelta(hours=24 * 3)
+
+        # Create DB data
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+            tsbds_0 = ts_0.get_timeseries_by_data_state(ds_1)
+            tsbds_4 = ts_4.get_timeseries_by_data_state(ds_1)
+        for i in range(24 * 3):
+            timestamp = start_dt + dt.timedelta(hours=i)
+            db.session.add(
+                TimeseriesData(
+                    timestamp=timestamp, timeseries_by_data_state_id=tsbds_0.id, value=i
+                )
+            )
+        for i in range(24 * 2):
+            timestamp = start_dt + dt.timedelta(hours=i)
+            db.session.add(
+                TimeseriesData(
+                    timestamp=timestamp,
+                    timeseries_by_data_state_id=tsbds_4.id,
+                    value=10 + 2 * i,
+                )
+            )
+        db.session.commit()
+
+        with CurrentUser(admin_user):
+
+            ts_l = (ts_0, ts_2, ts_4)
+
+            # Export CSV: UTC avg
+            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+                start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00+00:00",
+                    "2020-01-02T00:00:00+00:00",
+                    "2020-01-03T00:00:00+00:00",
+                ],
+                name="timestamp",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.name if col_label == "name" else ts_0.id: [11.5, 35.5, 59.5],
+                    ts_2.name
+                    if col_label == "name"
+                    else ts_2.id: [np.nan, np.nan, np.nan],
+                    ts_4.name if col_label == "name" else ts_4.id: [33.0, 81.0, np.nan],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
+            # Export CSV: local TZ avg
+            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+                start_dt,
+                end_dt,
+                ts_l,
+                ds_1,
+                "P1D",
+                timezone="Europe/Paris",
+                col_label=col_label,
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2019-12-31T23:00:00+0000",
+                    "2020-01-01T23:00:00+0000",
+                    "2020-01-02T23:00:00+0000",
+                    "2020-01-03T23:00:00+0000",
+                ],
+                name="timestamp",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.name
+                    if col_label == "name"
+                    else ts_0.id: [11.0, 34.5, 58.5, 71.0],
+                    ts_2.name
+                    if col_label == "name"
+                    else ts_2.id: [np.nan, np.nan, np.nan, np.nan],
+                    ts_4.name
+                    if col_label == "name"
+                    else ts_4.id: [32.0, 79.0, 104.0, np.nan],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
+            # Export CSV: UTC sum
+            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+                start_dt,
+                end_dt,
+                ts_l,
+                ds_1,
+                "1 day",
+                aggregation="sum",
+                col_label=col_label,
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00+0000",
+                    "2020-01-02T00:00:00+0000",
+                    "2020-01-03T00:00:00+0000",
+                ],
+                name="timestamp",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.name
+                    if col_label == "name"
+                    else ts_0.id: [276.0, 852.0, 1428.0],
+                    ts_2.name
+                    if col_label == "name"
+                    else ts_2.id: [np.nan, np.nan, np.nan],
+                    ts_4.name
+                    if col_label == "name"
+                    else ts_4.id: [792.0, 1944.0, np.nan],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
+            # Export CSV: UTC min
+            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+                start_dt,
+                end_dt,
+                ts_l,
+                ds_1,
+                "1 day",
+                aggregation="min",
+                col_label=col_label,
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00+0000",
+                    "2020-01-02T00:00:00+0000",
+                    "2020-01-03T00:00:00+0000",
+                ],
+                name="timestamp",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.name if col_label == "name" else ts_0.id: [0.0, 24.0, 48.0],
+                    ts_2.name
+                    if col_label == "name"
+                    else ts_2.id: [np.nan, np.nan, np.nan],
+                    ts_4.name if col_label == "name" else ts_4.id: [10.0, 58.0, np.nan],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
+            # Export CSV: UTC max
+            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+                start_dt,
+                end_dt,
+                ts_l,
+                ds_1,
+                "1 day",
+                aggregation="max",
+                col_label=col_label,
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00+0000",
+                    "2020-01-02T00:00:00+0000",
+                    "2020-01-03T00:00:00+0000",
+                ],
+                name="timestamp",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.name if col_label == "name" else ts_0.id: [23.0, 47.0, 71.0],
+                    ts_2.name
+                    if col_label == "name"
+                    else ts_2.id: [np.nan, np.nan, np.nan],
+                    ts_4.name
+                    if col_label == "name"
+                    else ts_4.id: [56.0, 104.0, np.nan],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
+            # Export CSV: invalid aggregation
+            with pytest.raises(TimeseriesDataIOInvalidAggregationError):
+                TimeseriesDataIO().get_timeseries_buckets_data(
+                    start_dt,
+                    end_dt,
+                    ts_l,
+                    ds_1,
+                    "1 day",
+                    aggregation="lol",
+                    col_label=col_label,
+                )
+
+    @pytest.mark.parametrize("timeseries", (5,), indirect=True)
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
+    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
+    @pytest.mark.parametrize("col_label", ("id", "name"))
+    def test_timeseries_data_io_export_csv_bucket_as_user(
+        self, users, timeseries, col_label
+    ):
+        user_1 = users[1]
+        assert not user_1.is_admin
+        ts_0 = timeseries[0]
+        ts_1 = timeseries[1]
+        ts_2 = timeseries[2]
+        ts_3 = timeseries[3]
+        ts_4 = timeseries[4]
+
+        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+        end_dt = start_dt + dt.timedelta(hours=24 * 3)
+
+        # Create DB data
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+            tsbds_1 = ts_1.get_timeseries_by_data_state(ds_1)
+            tsbds_3 = ts_3.get_timeseries_by_data_state(ds_1)
+            for i in range(24 * 3):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_1.id,
+                        value=i,
+                    )
+                )
+            for i in range(24 * 2):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_3.id,
+                        value=10 + 2 * i,
+                    )
+                )
+            db.session.commit()
+
+        with CurrentUser(user_1):
+
+            ts_l = (ts_0, ts_2, ts_4)
+
+            with pytest.raises(BEMServerAuthorizationError):
+                TimeseriesDataIO().get_timeseries_buckets_data(
+                    start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+                )
+
+            # Export CSV: UTC avg
+
+            ts_l = (ts_1, ts_3)
+
+            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+                start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00+0000",
+                    "2020-01-02T00:00:00+0000",
+                    "2020-01-03T00:00:00+0000",
+                ],
+                name="timestamp",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_1.name if col_label == "name" else ts_1.id: [11.5, 35.5, 59.5],
+                    ts_3.name if col_label == "name" else ts_3.id: [33.0, 81.0, np.nan],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
+    @pytest.mark.parametrize("timeseries", (5,), indirect=True)
+    def test_timeseries_data_io_delete_as_admin(
+        self,
+        users,
+        timeseries,
+    ):
+        admin_user = users[0]
+        assert admin_user.is_admin
+        ts_0 = timeseries[0]
+        ts_2 = timeseries[2]
+
+        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+        end_dt = start_dt + dt.timedelta(hours=3)
+
+        # Create DB data
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+            tsbds_0 = ts_0.get_timeseries_by_data_state(ds_1)
+            for i in range(3):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_0.id,
+                        value=i,
+                    )
+                )
+            db.session.commit()
+
+            assert db.session.query(TimeseriesData).all()
+
+        ts_l = (ts_0, ts_2)
+
+        with CurrentUser(admin_user):
+            TimeseriesDataIO().delete(start_dt, end_dt, ts_l, ds_1)
+            # Rollback then query to ensure data is actually deleted
+            db.session.rollback()
+            assert not db.session.query(TimeseriesData).all()
+
+    @pytest.mark.parametrize("timeseries", (4,), indirect=True)
+    @pytest.mark.usefixtures("users_by_user_groups")
+    @pytest.mark.usefixtures("user_groups_by_campaigns")
+    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
+    def test_timeseries_data_io_delete_as_user(self, users, timeseries):
+        user_1 = users[1]
+        assert not user_1.is_admin
+        ts_0 = timeseries[0]
+        ts_1 = timeseries[1]
+        ts_2 = timeseries[2]
+        ts_3 = timeseries[3]
+
+        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+        end_dt = start_dt + dt.timedelta(hours=3)
+
+        # Create DB data
+        with OpenBar():
+            ds_1 = TimeseriesDataState.get(name="Raw").first()
+            tsbds_0 = ts_0.get_timeseries_by_data_state(ds_1)
+            tsbds_1 = ts_1.get_timeseries_by_data_state(ds_1)
+            for i in range(3):
+                timestamp = start_dt + dt.timedelta(hours=i)
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_0.id,
+                        value=i,
+                    )
+                )
+                db.session.add(
+                    TimeseriesData(
+                        timestamp=timestamp,
+                        timeseries_by_data_state_id=tsbds_1.id,
+                        value=i,
+                    )
+                )
+            db.session.commit()
+
+            assert db.session.query(TimeseriesData).all()
+
+        ts_l = (ts_0, ts_2)
+
+        with CurrentUser(user_1):
+            with pytest.raises(BEMServerAuthorizationError):
+                TimeseriesDataIO().delete(start_dt, end_dt, ts_l, ds_1)
+
+        ts_l = (ts_1, ts_3)
+
+        with CurrentUser(user_1):
+            TimeseriesDataIO().delete(start_dt, end_dt, ts_l, ds_1)
+            # Rollback then query to ensure data is actually deleted
+            db.session.rollback()
+            assert (
+                not db.session.query(TimeseriesData)
+                .filter_by(timeseries_by_data_state_id=tsbds_1.id)
+                .all()
+            )
 
 
 class TestTimeseriesDataCSVIO:
@@ -544,101 +1261,4 @@ class TestTimeseriesDataCSVIO:
                 "2020-01-01T00:00:00+0000,11.5,33.0\n"
                 "2020-01-02T00:00:00+0000,35.5,81.0\n"
                 "2020-01-03T00:00:00+0000,59.5,\n"
-            )
-
-    @pytest.mark.parametrize("timeseries", (5,), indirect=True)
-    def test_timeseries_data_io_delete_as_admin(
-        self,
-        users,
-        timeseries,
-    ):
-        admin_user = users[0]
-        assert admin_user.is_admin
-        ts_0 = timeseries[0]
-        ts_2 = timeseries[2]
-
-        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
-        end_dt = start_dt + dt.timedelta(hours=3)
-
-        # Create DB data
-        with OpenBar():
-            ds_1 = TimeseriesDataState.get(name="Raw").first()
-            tsbds_0 = ts_0.get_timeseries_by_data_state(ds_1)
-            for i in range(3):
-                timestamp = start_dt + dt.timedelta(hours=i)
-                db.session.add(
-                    TimeseriesData(
-                        timestamp=timestamp,
-                        timeseries_by_data_state_id=tsbds_0.id,
-                        value=i,
-                    )
-                )
-            db.session.commit()
-
-            assert db.session.query(TimeseriesData).all()
-
-        ts_l = (ts_0, ts_2)
-
-        with CurrentUser(admin_user):
-            tsdcsvio.delete(start_dt, end_dt, ts_l, ds_1.id)
-            # Rollback then query to ensure data is actually deleted
-            db.session.rollback()
-            assert not db.session.query(TimeseriesData).all()
-
-    @pytest.mark.parametrize("timeseries", (4,), indirect=True)
-    @pytest.mark.usefixtures("users_by_user_groups")
-    @pytest.mark.usefixtures("user_groups_by_campaigns")
-    @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
-    def test_timeseries_data_io_delete_as_user(self, users, timeseries):
-        user_1 = users[1]
-        assert not user_1.is_admin
-        ts_0 = timeseries[0]
-        ts_1 = timeseries[1]
-        ts_2 = timeseries[2]
-        ts_3 = timeseries[3]
-
-        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
-        end_dt = start_dt + dt.timedelta(hours=3)
-
-        # Create DB data
-        with OpenBar():
-            ds_1 = TimeseriesDataState.get(name="Raw").first()
-            tsbds_0 = ts_0.get_timeseries_by_data_state(ds_1)
-            tsbds_1 = ts_1.get_timeseries_by_data_state(ds_1)
-            for i in range(3):
-                timestamp = start_dt + dt.timedelta(hours=i)
-                db.session.add(
-                    TimeseriesData(
-                        timestamp=timestamp,
-                        timeseries_by_data_state_id=tsbds_0.id,
-                        value=i,
-                    )
-                )
-                db.session.add(
-                    TimeseriesData(
-                        timestamp=timestamp,
-                        timeseries_by_data_state_id=tsbds_1.id,
-                        value=i,
-                    )
-                )
-            db.session.commit()
-
-            assert db.session.query(TimeseriesData).all()
-
-        ts_l = (ts_0, ts_2)
-
-        with CurrentUser(user_1):
-            with pytest.raises(BEMServerAuthorizationError):
-                tsdcsvio.delete(start_dt, end_dt, ts_l, ds_1)
-
-        ts_l = (ts_1, ts_3)
-
-        with CurrentUser(user_1):
-            tsdcsvio.delete(start_dt, end_dt, ts_l, ds_1.id)
-            # Rollback then query to ensure data is actually deleted
-            db.session.rollback()
-            assert (
-                not db.session.query(TimeseriesData)
-                .filter_by(timeseries_by_data_state_id=tsbds_1.id)
-                .all()
             )

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -12,8 +12,7 @@ from bemserver_core.model import (
     TimeseriesDataState,
     TimeseriesByDataState,
 )
-from bemserver_core.input_output import tsdcsvio
-from bemserver_core.input_output.timeseries_data_io import TimeseriesDataIO
+from bemserver_core.input_output import tsdio, tsdcsvio
 from bemserver_core.database import db
 from bemserver_core.authorization import CurrentUser, OpenBar
 from bemserver_core.exceptions import (
@@ -62,7 +61,7 @@ class TestTimeseriesDataIO:
         )
 
         with CurrentUser(admin_user):
-            TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+            tsdio.set_timeseries_data(data_df, ds_1, campaign)
 
         # Check TSBDS are correctly auto-created
         tsbds_l = (
@@ -150,7 +149,7 @@ class TestTimeseriesDataIO:
 
         with CurrentUser(user_1):
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+                tsdio.set_timeseries_data(data_df, ds_1, campaign)
 
         data_df = pd.DataFrame(
             {
@@ -165,7 +164,7 @@ class TestTimeseriesDataIO:
             campaign = None
 
         with CurrentUser(user_1):
-            TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+            tsdio.set_timeseries_data(data_df, ds_1, campaign)
 
     @pytest.mark.parametrize("for_campaign", (True, False))
     def test_timeseries_data_io_import_set_timeseries_data_timeseries_error(
@@ -196,7 +195,7 @@ class TestTimeseriesDataIO:
 
         with CurrentUser(admin_user):
             with pytest.raises(TimeseriesNotFoundError):
-                TimeseriesDataIO().set_timeseries_data(data_df, ds_1, campaign)
+                tsdio.set_timeseries_data(data_df, ds_1, campaign)
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.parametrize("col_label", ("id", "name"))
@@ -240,9 +239,7 @@ class TestTimeseriesDataIO:
         with CurrentUser(admin_user):
 
             ts_l = (ts_0, ts_2, ts_4)
-            data_df = TimeseriesDataIO().get_timeseries_data(
-                start_dt, end_dt, ts_l, ds_1, col_label
-            )
+            data_df = tsdio.get_timeseries_data(start_dt, end_dt, ts_l, ds_1, col_label)
 
         index = pd.DatetimeIndex(
             [
@@ -314,12 +311,12 @@ class TestTimeseriesDataIO:
             ts_l = (ts_0, ts_2, ts_4)
 
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesDataIO().get_timeseries_data(
+                tsdio.get_timeseries_data(
                     start_dt, end_dt, ts_l, ds_1, col_label=col_label
                 )
 
             ts_l = (ts_1, ts_3)
-            data_df = TimeseriesDataIO().get_timeseries_data(
+            data_df = tsdio.get_timeseries_data(
                 start_dt, end_dt, ts_l, ds_1, col_label=col_label
             )
 
@@ -384,7 +381,7 @@ class TestTimeseriesDataIO:
             ts_l = (ts_0, ts_2, ts_4)
 
             # Export CSV: UTC avg
-            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+            data_df = tsdio.get_timeseries_buckets_data(
                 start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
             )
 
@@ -410,7 +407,7 @@ class TestTimeseriesDataIO:
             assert data_df.equals(expected_data_df)
 
             # Export CSV: local TZ avg
-            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+            data_df = tsdio.get_timeseries_buckets_data(
                 start_dt,
                 end_dt,
                 ts_l,
@@ -447,7 +444,7 @@ class TestTimeseriesDataIO:
             assert data_df.equals(expected_data_df)
 
             # Export CSV: UTC sum
-            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+            data_df = tsdio.get_timeseries_buckets_data(
                 start_dt,
                 end_dt,
                 ts_l,
@@ -483,7 +480,7 @@ class TestTimeseriesDataIO:
             assert data_df.equals(expected_data_df)
 
             # Export CSV: UTC min
-            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+            data_df = tsdio.get_timeseries_buckets_data(
                 start_dt,
                 end_dt,
                 ts_l,
@@ -515,7 +512,7 @@ class TestTimeseriesDataIO:
             assert data_df.equals(expected_data_df)
 
             # Export CSV: UTC max
-            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+            data_df = tsdio.get_timeseries_buckets_data(
                 start_dt,
                 end_dt,
                 ts_l,
@@ -550,7 +547,7 @@ class TestTimeseriesDataIO:
 
             # Export CSV: invalid aggregation
             with pytest.raises(TimeseriesDataIOInvalidAggregationError):
-                TimeseriesDataIO().get_timeseries_buckets_data(
+                tsdio.get_timeseries_buckets_data(
                     start_dt,
                     end_dt,
                     ts_l,
@@ -609,7 +606,7 @@ class TestTimeseriesDataIO:
             ts_l = (ts_0, ts_2, ts_4)
 
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesDataIO().get_timeseries_buckets_data(
+                tsdio.get_timeseries_buckets_data(
                     start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
                 )
 
@@ -617,7 +614,7 @@ class TestTimeseriesDataIO:
 
             ts_l = (ts_1, ts_3)
 
-            data_df = TimeseriesDataIO().get_timeseries_buckets_data(
+            data_df = tsdio.get_timeseries_buckets_data(
                 start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
             )
 
@@ -673,7 +670,7 @@ class TestTimeseriesDataIO:
         ts_l = (ts_0, ts_2)
 
         with CurrentUser(admin_user):
-            TimeseriesDataIO().delete(start_dt, end_dt, ts_l, ds_1)
+            tsdio.delete(start_dt, end_dt, ts_l, ds_1)
             # Rollback then query to ensure data is actually deleted
             db.session.rollback()
             assert not db.session.query(TimeseriesData).all()
@@ -722,12 +719,12 @@ class TestTimeseriesDataIO:
 
         with CurrentUser(user_1):
             with pytest.raises(BEMServerAuthorizationError):
-                TimeseriesDataIO().delete(start_dt, end_dt, ts_l, ds_1)
+                tsdio.delete(start_dt, end_dt, ts_l, ds_1)
 
         ts_l = (ts_1, ts_3)
 
         with CurrentUser(user_1):
-            TimeseriesDataIO().delete(start_dt, end_dt, ts_l, ds_1)
+            tsdio.delete(start_dt, end_dt, ts_l, ds_1)
             # Rollback then query to ensure data is actually deleted
             db.session.rollback()
             assert (

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -63,6 +63,9 @@ class TestTimeseriesDataIO:
         with CurrentUser(admin_user):
             tsdio.set_timeseries_data(data_df, ds_1, campaign)
 
+        # Rollback then query to ensure data is actually written
+        db.session.rollback()
+
         # Check TSBDS are correctly auto-created
         tsbds_l = (
             db.session.query(TimeseriesByDataState)

--- a/tests/model/test_timeseries.py
+++ b/tests/model/test_timeseries.py
@@ -27,12 +27,12 @@ class TestTimeseriesPropertyModel:
         assert admin_user.is_admin
 
         with CurrentUser(admin_user):
-            assert not list(TimeseriesProperty.get())
+            nb_ts_properties = len(list(TimeseriesProperty.get()))
             ts_property_1 = TimeseriesProperty.new(name="Min")
             db.session.add(ts_property_1)
             db.session.commit()
             assert TimeseriesProperty.get_by_id(ts_property_1.id) == ts_property_1
-            assert len(list(TimeseriesProperty.get())) == 1
+            assert len(list(TimeseriesProperty.get())) == nb_ts_properties + 1
             ts_property_1.update(name="Max")
             ts_property_1.delete()
             db.session.commit()


### PR DESCRIPTION
Expose `TimeseriesDataIO` for core services.

- Use TS and TSDS instances (not IDs) as argument
- Use Dataframe as I/O format for `TimeseriesDataIO`
- Improve get queries: don't build TSBDS first