### PR TITLE
TimeseriesDateIO: rework bucket aggregations

### DIFF
--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -99,7 +99,7 @@ class TimeseriesDataIO:
 
     @classmethod
     def get_timeseries_data(
-        cls, start_dt, end_dt, timeseries, data_state, col_label="id"
+        cls, start_dt, end_dt, timeseries, data_state, *, col_label="name"
     ):
         """Export timeseries data
 
@@ -108,7 +108,7 @@ class TimeseriesDataIO:
         :param list timeseries: List of timeseries
         :param TimeseriesDataState data_state: Timeseries data state
         :param string col_label: Timeseries attribute to use for column header.
-            Should be "id" or "name". Default: "id".
+            Should be "id" or "name". Default: "name".
 
         Returns a dataframe.
         """
@@ -157,7 +157,7 @@ class TimeseriesDataIO:
         aggregation="avg",
         *,
         timezone="UTC",
-        col_label="id",
+        col_label="name",
     ):
         """Bucket timeseries data and export
 
@@ -173,7 +173,7 @@ class TimeseriesDataIO:
             "avg", "sum", "min", "max" and "count".
         :param str timezone: IANA timezone
         :param string col_label: Timeseries attribute to use for column header.
-            Should be "id" or "name". Default: "id".
+            Should be "id" or "name". Default: "name".
 
         The time alignment of the bucket depends on the bucket width unit.
         - For a size bucket width unit of day or smaller, the aggregation is

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -141,7 +141,10 @@ class TimeseriesDataIO:
         :param datetime end_dt: Time interval exclusive upper bound (tz-aware)
         :param list timeseries: List of timeseries
         :param TimeseriesDataState data_state: Timeseries data state
-        :param str bucket_width: Bucket width (ISO 8601 or PostgreSQL interval)
+        :param str bucket_width: Bucket width of the form "value unit" where
+            value is an int and unit a string in
+            {"second", "minute", "hour", "day", "week", "month", "year"}
+            E.g.: "1 day", "3 year"
         :param str timezone: IANA timezone
         :param str aggreagation: Aggregation function. Must be one of
             "avg", "sum", "min", "max" and "count".
@@ -319,7 +322,10 @@ class TimeseriesDataCSVIO(TimeseriesDataIO, BaseCSVIO):
         :param datetime end_dt: Time interval exclusive upper bound (tz-aware)
         :param list timeseries: List of timeseries
         :param TimeseriesDataState data_state: Timeseries data state
-        :param str bucket_width: Bucket width (ISO 8601 or PostgreSQL interval)
+        :param str bucket_width: Bucket width of the form "value unit" where
+            value is an int and unit a string in
+            {"second", "minute", "hour", "day", "week", "month", "year"}
+            E.g.: "1 day", "3 year"
         :param str timezone: IANA timezone
         :param str aggreagation: Aggregation function. Must be one of
             "avg", "sum", "min" and "max".

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -21,7 +21,7 @@ from bemserver_core.exceptions import (
 from .base import BaseCSVIO
 
 
-AGGREGATION_FUNCTIONS = ("avg", "sum", "min", "max")
+AGGREGATION_FUNCTIONS = ("avg", "sum", "min", "max", "count")
 
 
 class TimeseriesDataIO:
@@ -144,7 +144,7 @@ class TimeseriesDataIO:
         :param str bucket_width: Bucket width (ISO 8601 or PostgreSQL interval)
         :param str timezone: IANA timezone
         :param str aggreagation: Aggregation function. Must be one of
-            "avg", "sum", "min" and "max".
+            "avg", "sum", "min", "max" and "count".
         :param string col_label: Timeseries attribute to use for column header.
             Should be "id" or "name". Default: "id".
 

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -36,7 +36,8 @@ PANDAS_OFFSET_ALIASES = {
     "month": "MS",
     "year": "AS",
 }
-PANDAS_AGGREG_FUNC_MAPPING = {
+# Function to use to re-aggregate in pandas after SQL aggregation
+PANDAS_RE_AGGREG_FUNC_MAPPING = {
     "avg": "mean",
     "min": "min",
     "max": "max",
@@ -273,7 +274,7 @@ class TimeseriesDataIO:
         # Variable size intervals are aggregated to 1 x unit due to date_trunc
         # Further aggregation is achieved here in pandas
         if bw_unit in VARIABLE_SIZE_INTERVAL_UNITS:
-            func = PANDAS_AGGREG_FUNC_MAPPING[aggregation]
+            func = PANDAS_RE_AGGREG_FUNC_MAPPING[aggregation]
             # Pandas docs say origin TZ must match dataframe index TZ
             origin = start_dt.astimezone(data_df.index.tzinfo)
             data_df = data_df.resample(

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -115,6 +115,7 @@ class TimeseriesDataIO:
         data_df = pd.DataFrame(
             data, columns=("timestamp", "id", "name", "value")
         ).set_index("timestamp")
+        data_df["value"] = data_df["value"].astype(float)
         data_df.index = pd.DatetimeIndex(data_df.index)
 
         data_df = data_df.pivot(columns=col_label, values="value")

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -185,9 +185,7 @@ class TimeseriesDataIO:
         data_df = pd.DataFrame(
             data, columns=("timestamp", "id", "name", "value")
         ).set_index("timestamp")
-        data_df.index = (
-            pd.DatetimeIndex(data_df.index).tz_localize(timezone).tz_convert("UTC")
-        )
+        data_df.index = pd.DatetimeIndex(data_df.index).tz_localize(timezone)
         data_df = data_df.pivot(columns=col_label, values="value")
 
         cls._fill_missing_columns(data_df, timeseries, col_label)

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -397,8 +397,9 @@ class TimeseriesDataCSVIO(TimeseriesDataIO, BaseCSVIO):
         timeseries,
         data_state,
         bucket_width,
-        timezone="UTC",
         aggregation="avg",
+        *,
+        timezone="UTC",
         col_label="id",
     ):
         """Bucket timeseries data and export as CSV file
@@ -411,9 +412,9 @@ class TimeseriesDataCSVIO(TimeseriesDataIO, BaseCSVIO):
             value is an int and unit a string in
             {"second", "minute", "hour", "day", "week", "month", "year"}
             E.g.: "1 day", "3 year"
-        :param str timezone: IANA timezone
         :param str aggreagation: Aggregation function. Must be one of
             "avg", "sum", "min" and "max".
+        :param str timezone: IANA timezone
         :param string col_label: Timeseries attribute to use for column header.
             Should be "id" or "name". Default: "id".
 
@@ -425,8 +426,8 @@ class TimeseriesDataCSVIO(TimeseriesDataIO, BaseCSVIO):
             timeseries,
             data_state,
             bucket_width,
+            aggregation,
             timezone=timezone,
-            aggregation=aggregation,
             col_label=col_label,
         )
         data_df.index.name = "Datetime"

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -68,12 +68,12 @@ class TimeseriesDataIO:
         db.session.commit()
 
     @staticmethod
-    def _fill_missing_columns(data_df, ts_l, attr):
+    def _fill_missing_columns(data_df, ts_l, attr, fill_value=np.nan):
         """Add missing columns, in query order"""
         for idx, ts in enumerate(ts_l):
             val = getattr(ts, attr)
             if val not in data_df:
-                data_df.insert(idx, val, np.nan)
+                data_df.insert(idx, val, fill_value)
 
     @classmethod
     def get_timeseries_data(

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -437,12 +437,7 @@ class TimeseriesDataCSVIO(TimeseriesDataIO, BaseCSVIO):
     def export_csv(cls, start_dt, end_dt, timeseries, data_state, col_label="id"):
         """Export timeseries data as CSV file
 
-        :param datetime start_dt: Time interval lower bound (tz-aware)
-        :param datetime end_dt: Time interval exclusive upper bound (tz-aware)
-        :param list timeseries: List of timeseries
-        :param TimeseriesDataState data_state: Timeseries data state
-        :param string col_label: Timeseries attribute to use for column header.
-            Should be "id" or "name". Default: "id".
+        See ``TimeseriesDataIO.get_timeseries_data``.
 
         Returns csv as a string.
         """
@@ -474,19 +469,7 @@ class TimeseriesDataCSVIO(TimeseriesDataIO, BaseCSVIO):
     ):
         """Bucket timeseries data and export as CSV file
 
-        :param datetime start_dt: Time interval lower bound (tz-aware)
-        :param datetime end_dt: Time interval exclusive upper bound (tz-aware)
-        :param list timeseries: List of timeseries
-        :param TimeseriesDataState data_state: Timeseries data state
-        :param str bucket_width: Bucket width of the form "value unit" where
-            value is an int and unit a string in
-            {"second", "minute", "hour", "day", "week", "month", "year"}
-            E.g.: "1 day", "3 year"
-        :param str aggreagation: Aggregation function. Must be one of
-            "avg", "sum", "min" and "max".
-        :param str timezone: IANA timezone
-        :param string col_label: Timeseries attribute to use for column header.
-            Should be "id" or "name". Default: "id".
+        See ``TimeseriesDataIO.get_timeseries_buckets_data``.
 
         Returns csv as a string.
         """

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -548,6 +548,38 @@ class TestTimeseriesDataIO:
 
             assert data_df.equals(expected_data_df)
 
+            # Export CSV: UTC count
+            data_df = tsdio.get_timeseries_buckets_data(
+                start_dt,
+                end_dt,
+                ts_l,
+                ds_1,
+                "1 day",
+                aggregation="count",
+                col_label=col_label,
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00+0000",
+                    "2020-01-02T00:00:00+0000",
+                    "2020-01-03T00:00:00+0000",
+                ],
+                name="timestamp",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.name if col_label == "name" else ts_0.id: [24.0, 24.0, 24.0],
+                    ts_2.name
+                    if col_label == "name"
+                    else ts_2.id: [np.nan, np.nan, np.nan],
+                    ts_4.name if col_label == "name" else ts_4.id: [24.0, 24.0, np.nan],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
             # Export CSV: invalid aggregation
             with pytest.raises(TimeseriesDataIOInvalidAggregationError):
                 tsdio.get_timeseries_buckets_data(

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -507,10 +507,10 @@ class TestTimeseriesDataIO:
 
             assert data_df.equals(expected_data_df)
 
-            # Export CSV: UTC count 1 week, start on thursday 26th, local TZ
+            # Export CSV: local TZ count 1 week
             data_df = tsdio.get_timeseries_buckets_data(
                 # Check start_dt TZ doesn't change alignment to 00:00 local TZ
-                dt.datetime(2019, 12, 26, tzinfo=dt.timezone.utc),
+                dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
                 dt.datetime(2020, 1, 9, tzinfo=ZoneInfo("Europe/Paris")),
                 ts_l,
                 ds_1,
@@ -522,17 +522,17 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2019-12-26T00:00:00",
-                    "2020-01-02T00:00:00",
+                    "2019-12-30T00:00:00",
+                    "2020-01-06T00:00:00",
                 ],
                 name="timestamp",
                 tz="Europe/Paris",
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_0.name: [23, 49],
+                    ts_0.name: [72, 0],
                     ts_2.name: [0, 0],
-                    ts_4.name: [23, 25],
+                    ts_4.name: [48, 0],
                 },
                 index=index,
             )

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -873,50 +873,10 @@ class TestTimeseriesDataIO:
 
             assert data_df.equals(expected_data_df)
 
-            # Export CSV: UTC count year with offset
+            # Export CSV: local TZ count year (first bucket incomplete)
             data_df = tsdio.get_timeseries_buckets_data(
-                start_dt_plus_3_months,
-                end_dt,
-                ts_l,
-                ds_1,
-                "1 year",
-                "count",
-                col_label="name",
-            )
-
-            index = pd.DatetimeIndex(
-                [
-                    "2020-04-01T00:00:00",
-                    "2021-04-01T00:00:00",
-                ],
-                name="timestamp",
-                tz="UTC",
-            )
-            expected_data_df = pd.DataFrame(
-                {
-                    ts_0.name: [
-                        # April 2020 -> April 2021
-                        24 * 365,
-                        # April 2021 -> Jan 2022
-                        24 * (365 - (31 + 28 + 31)),
-                    ],
-                    ts_2.name: [0, 0],
-                    ts_4.name: [
-                        # April 2020 -> Jan 2021
-                        24 * (365 - (31 + 28 + 31)),
-                        0,
-                    ],
-                },
-                index=index,
-            )
-
-            assert data_df.equals(expected_data_df)
-
-            # Export CSV: local TZ count year with offset
-            # Start date is UTC so first bucket is incomplete
-            data_df = tsdio.get_timeseries_buckets_data(
-                start_dt_plus_3_months,
-                end_dt,
+                start_dt_plus_3_months.replace(tzinfo=ZoneInfo("Europe/Paris")),
+                end_dt.replace(tzinfo=ZoneInfo("Europe/Paris")),
                 ts_l,
                 ds_1,
                 "1 year",
@@ -927,8 +887,8 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2020-04-01T00:00:00",
-                    "2021-04-01T00:00:00",
+                    "2020-01-01T00:00:00",
+                    "2021-01-01T00:00:00",
                 ],
                 name="timestamp",
                 tz="Europe/Paris",
@@ -936,16 +896,17 @@ class TestTimeseriesDataIO:
             expected_data_df = pd.DataFrame(
                 {
                     ts_0.name: [
-                        # April 2020 UTC -> April 2021 UTC+2
-                        24 * 365 - 2,
-                        # April 2021 UTC +2 -> Jan 2022 UTC
-                        24 * (365 - (31 + 28 + 31)) + 2,
+                        # Apr 2020 UTC+2 -> Jan 2021 UTC+1
+                        24 * (30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31) + 1,
+                        # Apr 2021 UTC+2 -> Jan 2022 UTC+1
+                        24 * 365,
                     ],
                     ts_2.name: [0, 0],
                     ts_4.name: [
-                        # April 2020 UTC -> Jan 2021 UTC
-                        24 * (365 - (31 + 28 + 31)),
-                        0,
+                        # Apr 2020 UTC+2 -> Jan 2021 UTC+1
+                        24 * (30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31) + 1,
+                        # Jan 2021 UTC+1 -> Jan 2022 UTC
+                        1,
                     ],
                 },
                 index=index,

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -344,9 +344,8 @@ class TestTimeseriesDataIO:
         assert data_df.equals(expected_data_df)
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
-    @pytest.mark.parametrize("col_label", ("id", "name"))
     def test_timeseries_data_io_get_timeseries_buckets_data_fixed_size_as_admin(
-        self, users, timeseries, col_label
+        self, users, timeseries
     ):
         admin_user = users[0]
         assert admin_user.is_admin
@@ -383,11 +382,6 @@ class TestTimeseriesDataIO:
         with CurrentUser(admin_user):
 
             ts_l = (ts_0, ts_2, ts_4)
-            ts_id_l = (
-                ts_0.name if col_label == "name" else ts_0.id,
-                ts_2.name if col_label == "name" else ts_2.id,
-                ts_4.name if col_label == "name" else ts_4.id,
-            )
 
             # Export CSV: UTC count 1 day
             data_df = tsdio.get_timeseries_buckets_data(
@@ -397,7 +391,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 day",
                 "count",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -411,9 +405,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [24, 24, 24],
-                    ts_id_l[1]: [0, 0, 0],
-                    ts_id_l[2]: [24, 24, 0],
+                    ts_0.name: [24, 24, 24],
+                    ts_2.name: [0, 0, 0],
+                    ts_4.name: [24, 24, 0],
                 },
                 index=index,
             )
@@ -427,7 +421,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "2 day",
                 "count",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -440,9 +434,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [48, 24],
-                    ts_id_l[1]: [0, 0],
-                    ts_id_l[2]: [48, 0],
+                    ts_0.name: [48, 24],
+                    ts_2.name: [0, 0],
+                    ts_4.name: [48, 0],
                 },
                 index=index,
             )
@@ -457,7 +451,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 week",
                 "count",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -470,9 +464,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [24, 48],
-                    ts_id_l[1]: [0, 0],
-                    ts_id_l[2]: [24, 24],
+                    ts_0.name: [24, 48],
+                    ts_2.name: [0, 0],
+                    ts_4.name: [24, 24],
                 },
                 index=index,
             )
@@ -487,7 +481,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "12 hour",
                 "count",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -504,9 +498,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: 6 * [12],
-                    ts_id_l[1]: 6 * [0],
-                    ts_id_l[2]: 4 * [12] + 2 * [0],
+                    ts_0.name: 6 * [12],
+                    ts_2.name: 6 * [0],
+                    ts_4.name: 4 * [12] + 2 * [0],
                 },
                 index=index,
             )
@@ -520,7 +514,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 day",
                 timezone="Europe/Paris",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -535,9 +529,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [11.0, 34.5, 58.5, 71.0],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [32.0, 79.0, 104.0, np.nan],
+                    ts_0.name: [11.0, 34.5, 58.5, 71.0],
+                    ts_2.name: [np.nan, np.nan, np.nan, np.nan],
+                    ts_4.name: [32.0, 79.0, 104.0, np.nan],
                 },
                 index=index,
             )
@@ -552,7 +546,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 day",
                 "sum",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -566,9 +560,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [276.0, 852.0, 1428.0],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [792.0, 1944.0, np.nan],
+                    ts_0.name: [276.0, 852.0, 1428.0],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [792.0, 1944.0, np.nan],
                 },
                 index=index,
             )
@@ -583,7 +577,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 day",
                 "min",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -597,9 +591,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [0.0, 24.0, 48.0],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [10.0, 58.0, np.nan],
+                    ts_0.name: [0.0, 24.0, 48.0],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [10.0, 58.0, np.nan],
                 },
                 index=index,
             )
@@ -614,7 +608,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 day",
                 "max",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -628,13 +622,43 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [23.0, 47.0, 71.0],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [56.0, 104.0, np.nan],
+                    ts_0.name: [23.0, 47.0, 71.0],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [56.0, 104.0, np.nan],
                 },
                 index=index,
             )
 
+            assert data_df.equals(expected_data_df)
+
+            # Export CSV: UTC count 1 day by ID
+            data_df = tsdio.get_timeseries_buckets_data(
+                start_dt,
+                end_dt,
+                ts_l,
+                ds_1,
+                "1 day",
+                "count",
+                col_label="id",
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
+                ],
+                name="timestamp",
+                tz="UTC",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.id: [24, 24, 24],
+                    ts_2.id: [0, 0, 0],
+                    ts_4.id: [24, 24, 0],
+                },
+                index=index,
+            )
             assert data_df.equals(expected_data_df)
 
             # Export CSV: invalid aggregation
@@ -646,13 +670,11 @@ class TestTimeseriesDataIO:
                     ds_1,
                     "1 day",
                     "lol",
-                    col_label=col_label,
                 )
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
-    @pytest.mark.parametrize("col_label", ("id", "name"))
     def test_timeseries_data_io_get_timeseries_buckets_data_variable_size_as_admin(
-        self, users, timeseries, col_label
+        self, users, timeseries
     ):
         admin_user = users[0]
         assert admin_user.is_admin
@@ -704,15 +726,10 @@ class TestTimeseriesDataIO:
         with CurrentUser(admin_user):
 
             ts_l = (ts_0, ts_2, ts_4)
-            ts_id_l = (
-                ts_0.name if col_label == "name" else ts_0.id,
-                ts_2.name if col_label == "name" else ts_2.id,
-                ts_4.name if col_label == "name" else ts_4.id,
-            )
 
             # Export CSV: UTC count year
             data_df = tsdio.get_timeseries_buckets_data(
-                start_dt, end_dt, ts_l, ds_1, "1 year", "count", col_label=col_label
+                start_dt, end_dt, ts_l, ds_1, "1 year", "count", col_label="name"
             )
 
             index = pd.DatetimeIndex(
@@ -725,9 +742,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [24 * 366, 24 * 365],
-                    ts_id_l[1]: [0, 0],
-                    ts_id_l[2]: [24 * 366, 0],
+                    ts_0.name: [24 * 366, 24 * 365],
+                    ts_2.name: [0, 0],
+                    ts_4.name: [24 * 366, 0],
                 },
                 index=index,
             )
@@ -736,7 +753,7 @@ class TestTimeseriesDataIO:
 
             # Export CSV: UTC count 2 year
             data_df = tsdio.get_timeseries_buckets_data(
-                start_dt, end_dt, ts_l, ds_1, "2 year", "count", col_label=col_label
+                start_dt, end_dt, ts_l, ds_1, "2 year", "count", col_label="name"
             )
 
             index = pd.DatetimeIndex(
@@ -748,9 +765,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [24 * 366 + 24 * 365],
-                    ts_id_l[1]: [0],
-                    ts_id_l[2]: [24 * 366],
+                    ts_0.name: [24 * 366 + 24 * 365],
+                    ts_2.name: [0],
+                    ts_4.name: [24 * 366],
                 },
                 index=index,
             )
@@ -765,7 +782,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 year",
                 "count",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -778,14 +795,14 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [
+                    ts_0.name: [
                         # April 2020 -> April 2021
                         24 * 365,
                         # April 2021 -> Jan 2022
                         24 * (365 - (31 + 28 + 31)),
                     ],
-                    ts_id_l[1]: [0, 0],
-                    ts_id_l[2]: [
+                    ts_2.name: [0, 0],
+                    ts_4.name: [
                         # April 2020 -> Jan 2021
                         24 * (365 - (31 + 28 + 31)),
                         0,
@@ -806,7 +823,7 @@ class TestTimeseriesDataIO:
                 "1 year",
                 "count",
                 timezone="Europe/Paris",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -819,14 +836,14 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [
+                    ts_0.name: [
                         # April 2020 UTC -> April 2021 UTC+2
                         24 * 365 - 2,
                         # April 2021 UTC +2 -> Jan 2022 UTC
                         24 * (365 - (31 + 28 + 31)) + 2,
                     ],
-                    ts_id_l[1]: [0, 0],
-                    ts_id_l[2]: [
+                    ts_2.name: [0, 0],
+                    ts_4.name: [
                         # April 2020 UTC -> Jan 2021 UTC
                         24 * (365 - (31 + 28 + 31)),
                         0,
@@ -845,7 +862,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 month",
                 "avg",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -859,9 +876,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [371.5, 1091.5, 1811.5],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [753.0, 2193.0, 3633.0],
+                    ts_0.name: [371.5, 1091.5, 1811.5],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [753.0, 2193.0, 3633.0],
                 },
                 index=index,
             )
@@ -877,7 +894,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 month",
                 "avg",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -891,9 +908,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [407.5, 1091.5, 1811.5],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [825.0, 2193.0, 3633.0],
+                    ts_0.name: [407.5, 1091.5, 1811.5],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [825.0, 2193.0, 3633.0],
                 },
                 index=index,
             )
@@ -908,7 +925,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "2 month",
                 "avg",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -921,9 +938,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [731.5, 1811.5],
-                    ts_id_l[1]: [np.nan, np.nan],
-                    ts_id_l[2]: [1473.0, 3633.0],
+                    ts_0.name: [731.5, 1811.5],
+                    ts_2.name: [np.nan, np.nan],
+                    ts_4.name: [1473.0, 3633.0],
                 },
                 index=index,
             )
@@ -939,7 +956,7 @@ class TestTimeseriesDataIO:
                 "1 month",
                 "avg",
                 timezone="Europe/Paris",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -954,9 +971,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [371.0, 1090.5, 1810.0, 2182.5],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [752.0, 2191.0, 3630.0, 4375.0],
+                    ts_0.name: [371.0, 1090.5, 1810.0, 2182.5],
+                    ts_2.name: [np.nan, np.nan, np.nan, np.nan],
+                    ts_4.name: [752.0, 2191.0, 3630.0, 4375.0],
                 },
                 index=index,
             )
@@ -971,7 +988,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 month",
                 "sum",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -985,9 +1002,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [276396.0, 759684.0, 1347756.0],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [560232.0, 1526328.0, 2702952.0],
+                    ts_0.name: [276396.0, 759684.0, 1347756.0],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [560232.0, 1526328.0, 2702952.0],
                 },
                 index=index,
             )
@@ -1002,7 +1019,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 month",
                 "min",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -1016,9 +1033,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [0.0, 744.0, 1440.0],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [10.0, 1498.0, 2890.0],
+                    ts_0.name: [0.0, 744.0, 1440.0],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [10.0, 1498.0, 2890.0],
                 },
                 index=index,
             )
@@ -1033,7 +1050,7 @@ class TestTimeseriesDataIO:
                 ds_1,
                 "1 month",
                 "max",
-                col_label=col_label,
+                col_label="name",
             )
 
             index = pd.DatetimeIndex(
@@ -1047,9 +1064,33 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_id_l[0]: [743.0, 1439.0, 2183.0],
-                    ts_id_l[1]: [np.nan, np.nan, np.nan],
-                    ts_id_l[2]: [1496.0, 2888.0, 4376.0],
+                    ts_0.name: [743.0, 1439.0, 2183.0],
+                    ts_2.name: [np.nan, np.nan, np.nan],
+                    ts_4.name: [1496.0, 2888.0, 4376.0],
+                },
+                index=index,
+            )
+
+            assert data_df.equals(expected_data_df)
+
+            # Export CSV: UTC count year by ID
+            data_df = tsdio.get_timeseries_buckets_data(
+                start_dt, end_dt, ts_l, ds_1, "1 year", "count", col_label="id"
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00",
+                    "2021-01-01T00:00:00",
+                ],
+                name="timestamp",
+                tz="UTC",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.id: [24 * 366, 24 * 365],
+                    ts_2.id: [0, 0],
+                    ts_4.id: [24 * 366, 0],
                 },
                 index=index,
             )

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -1636,7 +1636,7 @@ class TestTimeseriesDataCSVIO:
                 ts_l,
                 ds_1,
                 "1 day",
-                aggregation="sum",
+                "sum",
                 col_label=col_label,
             )
             assert data == header + (
@@ -1652,7 +1652,7 @@ class TestTimeseriesDataCSVIO:
                 ts_l,
                 ds_1,
                 "1 day",
-                aggregation="min",
+                "min",
                 col_label=col_label,
             )
             assert data == header + (
@@ -1668,7 +1668,7 @@ class TestTimeseriesDataCSVIO:
                 ts_l,
                 ds_1,
                 "1 day",
-                aggregation="max",
+                "max",
                 col_label=col_label,
             )
             assert data == header + (
@@ -1685,7 +1685,7 @@ class TestTimeseriesDataCSVIO:
                     ts_l,
                     ds_1,
                     "1 day",
-                    aggregation="lol",
+                    "lol",
                     col_label=col_label,
                 )
 

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -382,6 +382,11 @@ class TestTimeseriesDataIO:
         with CurrentUser(admin_user):
 
             ts_l = (ts_0, ts_2, ts_4)
+            ts_id_l = (
+                ts_0.name if col_label == "name" else ts_0.id,
+                ts_2.name if col_label == "name" else ts_2.id,
+                ts_4.name if col_label == "name" else ts_4.id,
+            )
 
             # Export CSV: UTC avg
             data_df = tsdio.get_timeseries_buckets_data(
@@ -399,11 +404,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_0.name if col_label == "name" else ts_0.id: [11.5, 35.5, 59.5],
-                    ts_2.name
-                    if col_label == "name"
-                    else ts_2.id: [np.nan, np.nan, np.nan],
-                    ts_4.name if col_label == "name" else ts_4.id: [33.0, 81.0, np.nan],
+                    ts_id_l[0]: [11.5, 35.5, 59.5],
+                    ts_id_l[1]: [np.nan, np.nan, np.nan],
+                    ts_id_l[2]: [33.0, 81.0, np.nan],
                 },
                 index=index,
             )
@@ -433,15 +436,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_0.name
-                    if col_label == "name"
-                    else ts_0.id: [11.0, 34.5, 58.5, 71.0],
-                    ts_2.name
-                    if col_label == "name"
-                    else ts_2.id: [np.nan, np.nan, np.nan, np.nan],
-                    ts_4.name
-                    if col_label == "name"
-                    else ts_4.id: [32.0, 79.0, 104.0, np.nan],
+                    ts_id_l[0]: [11.0, 34.5, 58.5, 71.0],
+                    ts_id_l[1]: [np.nan, np.nan, np.nan, np.nan],
+                    ts_id_l[2]: [32.0, 79.0, 104.0, np.nan],
                 },
                 index=index,
             )
@@ -470,15 +467,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_0.name
-                    if col_label == "name"
-                    else ts_0.id: [276.0, 852.0, 1428.0],
-                    ts_2.name
-                    if col_label == "name"
-                    else ts_2.id: [np.nan, np.nan, np.nan],
-                    ts_4.name
-                    if col_label == "name"
-                    else ts_4.id: [792.0, 1944.0, np.nan],
+                    ts_id_l[0]: [276.0, 852.0, 1428.0],
+                    ts_id_l[1]: [np.nan, np.nan, np.nan],
+                    ts_id_l[2]: [792.0, 1944.0, np.nan],
                 },
                 index=index,
             )
@@ -507,11 +498,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_0.name if col_label == "name" else ts_0.id: [0.0, 24.0, 48.0],
-                    ts_2.name
-                    if col_label == "name"
-                    else ts_2.id: [np.nan, np.nan, np.nan],
-                    ts_4.name if col_label == "name" else ts_4.id: [10.0, 58.0, np.nan],
+                    ts_id_l[0]: [0.0, 24.0, 48.0],
+                    ts_id_l[1]: [np.nan, np.nan, np.nan],
+                    ts_id_l[2]: [10.0, 58.0, np.nan],
                 },
                 index=index,
             )
@@ -540,13 +529,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_0.name if col_label == "name" else ts_0.id: [23.0, 47.0, 71.0],
-                    ts_2.name
-                    if col_label == "name"
-                    else ts_2.id: [np.nan, np.nan, np.nan],
-                    ts_4.name
-                    if col_label == "name"
-                    else ts_4.id: [56.0, 104.0, np.nan],
+                    ts_id_l[0]: [23.0, 47.0, 71.0],
+                    ts_id_l[1]: [np.nan, np.nan, np.nan],
+                    ts_id_l[2]: [56.0, 104.0, np.nan],
                 },
                 index=index,
             )
@@ -574,11 +559,9 @@ class TestTimeseriesDataIO:
             )
             expected_data_df = pd.DataFrame(
                 {
-                    ts_0.name if col_label == "name" else ts_0.id: [24.0, 24.0, 24.0],
-                    ts_2.name
-                    if col_label == "name"
-                    else ts_2.id: [np.nan, np.nan, np.nan],
-                    ts_4.name if col_label == "name" else ts_4.id: [24.0, 24.0, np.nan],
+                    ts_id_l[0]: [24.0, 24.0, 24.0],
+                    ts_id_l[1]: [np.nan, np.nan, np.nan],
+                    ts_id_l[2]: [24.0, 24.0, np.nan],
                 },
                 index=index,
             )

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -390,11 +390,12 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2020-01-01T00:00:00+00:00",
-                    "2020-01-02T00:00:00+00:00",
-                    "2020-01-03T00:00:00+00:00",
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
                 ],
                 name="timestamp",
+                tz="UTC",
             )
             expected_data_df = pd.DataFrame(
                 {
@@ -422,12 +423,13 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2019-12-31T23:00:00+0000",
-                    "2020-01-01T23:00:00+0000",
-                    "2020-01-02T23:00:00+0000",
-                    "2020-01-03T23:00:00+0000",
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
+                    "2020-01-04T00:00:00",
                 ],
                 name="timestamp",
+                tz="Europe/Paris",
             )
             expected_data_df = pd.DataFrame(
                 {
@@ -459,11 +461,12 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2020-01-01T00:00:00+0000",
-                    "2020-01-02T00:00:00+0000",
-                    "2020-01-03T00:00:00+0000",
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
                 ],
                 name="timestamp",
+                tz="UTC",
             )
             expected_data_df = pd.DataFrame(
                 {
@@ -495,11 +498,12 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2020-01-01T00:00:00+0000",
-                    "2020-01-02T00:00:00+0000",
-                    "2020-01-03T00:00:00+0000",
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
                 ],
                 name="timestamp",
+                tz="UTC",
             )
             expected_data_df = pd.DataFrame(
                 {
@@ -527,11 +531,12 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2020-01-01T00:00:00+0000",
-                    "2020-01-02T00:00:00+0000",
-                    "2020-01-03T00:00:00+0000",
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
                 ],
                 name="timestamp",
+                tz="UTC",
             )
             expected_data_df = pd.DataFrame(
                 {
@@ -655,11 +660,12 @@ class TestTimeseriesDataIO:
 
             index = pd.DatetimeIndex(
                 [
-                    "2020-01-01T00:00:00+0000",
-                    "2020-01-02T00:00:00+0000",
-                    "2020-01-03T00:00:00+0000",
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
                 ],
                 name="timestamp",
+                tz="UTC",
             )
             expected_data_df = pd.DataFrame(
                 {
@@ -1158,10 +1164,10 @@ class TestTimeseriesDataCSVIO:
                 col_label=col_label,
             )
             assert data == header + (
-                "2019-12-31T23:00:00+0000,11.0,,32.0\n"
-                "2020-01-01T23:00:00+0000,34.5,,79.0\n"
-                "2020-01-02T23:00:00+0000,58.5,,104.0\n"
-                "2020-01-03T23:00:00+0000,71.0,,\n"
+                "2020-01-01T00:00:00+0100,11.0,,32.0\n"
+                "2020-01-02T00:00:00+0100,34.5,,79.0\n"
+                "2020-01-03T00:00:00+0100,58.5,,104.0\n"
+                "2020-01-04T00:00:00+0100,71.0,,\n"
             )
 
             # Export CSV: UTC sum

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -419,7 +419,7 @@ class TestTimeseriesDataIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "P1D",
+                "1 day",
                 timezone="Europe/Paris",
                 col_label=col_label,
             )
@@ -1142,7 +1142,7 @@ class TestTimeseriesDataCSVIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "P1D",
+                "1 day",
                 timezone="Europe/Paris",
                 col_label=col_label,
             )

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -244,7 +244,9 @@ class TestTimeseriesDataIO:
         with CurrentUser(admin_user):
 
             ts_l = (ts_0, ts_2, ts_4)
-            data_df = tsdio.get_timeseries_data(start_dt, end_dt, ts_l, ds_1, col_label)
+            data_df = tsdio.get_timeseries_data(
+                start_dt, end_dt, ts_l, ds_1, col_label=col_label
+            )
 
         index = pd.DatetimeIndex(
             [


### PR DESCRIPTION
- Fix aggregations for all bucket widths
- Limit bucket width format to "integer unit", with unit in "second", "minute", "hour", "day", "week", "month", "year"
- Fill gaps: add timestamps for missing values
- Return timestamps as aware datetimes in timezone
- Improve bucket alignment depending on bucket width
- Make col_label kw-only and default to "name"