### PR TITLE
Rework aggregation functions

### DIFF
--- a/bemserver_core/exceptions.py
+++ b/bemserver_core/exceptions.py
@@ -29,6 +29,10 @@ class TimeseriesDataIOError(BEMServerCoreIOError):
     """Timeseries data IO error"""
 
 
+class TimeseriesDataIOInvalidBucketWidthError(TimeseriesDataIOError):
+    """Timeseries data IO invalid bucket width error"""
+
+
 class TimeseriesDataIOInvalidAggregationError(TimeseriesDataIOError):
     """Timeseries data IO invalid aggregation error"""
 

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -141,7 +141,7 @@ class TimeseriesDataIO:
 
     @classmethod
     def get_timeseries_data(
-        cls, start_dt, end_dt, timeseries, data_state, *, col_label="name"
+        cls, start_dt, end_dt, timeseries, data_state, *, col_label="id"
     ):
         """Export timeseries data
 
@@ -150,7 +150,7 @@ class TimeseriesDataIO:
         :param list timeseries: List of timeseries
         :param TimeseriesDataState data_state: Timeseries data state
         :param string col_label: Timeseries attribute to use for column header.
-            Should be "id" or "name". Default: "name".
+            Should be "id" or "name". Default: "id".
 
         Returns a dataframe.
         """
@@ -199,7 +199,7 @@ class TimeseriesDataIO:
         aggregation="avg",
         *,
         timezone="UTC",
-        col_label="name",
+        col_label="id",
     ):
         """Bucket timeseries data and export
 
@@ -215,7 +215,7 @@ class TimeseriesDataIO:
             "avg", "sum", "min", "max" and "count".
         :param str timezone: IANA timezone
         :param string col_label: Timeseries attribute to use for column header.
-            Should be "id" or "name". Default: "name".
+            Should be "id" or "name". Default: "id".
 
         The time alignment of the bucket depends on the bucket width unit.
         - For a size bucket width unit of day or smaller, the aggregation is

--- a/bemserver_core/process/completeness.py
+++ b/bemserver_core/process/completeness.py
@@ -38,7 +38,6 @@ def compute_completeness(
         bucket_width,
         "count",
         timezone=timezone,
-        col_label="name",
     )
     avg_counts_df = counts_df.mean()
     total_counts_df = counts_df.sum()
@@ -96,6 +95,7 @@ def compute_completeness(
         "timestamps": ratios_df.index.to_list(),
         "timeseries": {
             col: {
+                "name": timeseries[idx].name,
                 "count": counts_df[col].to_list(),
                 "ratio": ratios_df[col].to_list(),
                 "total_count": total_counts_df[col],

--- a/bemserver_core/process/completeness.py
+++ b/bemserver_core/process/completeness.py
@@ -16,13 +16,18 @@ from bemserver_core.input_output.timeseries_data_io import (
 
 
 def compute_completeness(
-    start_dt, end_dt, timeseries, data_state, bucket_width, timezone="UTC"
+    start_dt,
+    end_dt,
+    timeseries,
+    data_state,
+    bucket_width_value,
+    bucket_width_unit,
+    timezone="UTC",
 ):
-    bw_val, bw_unit = bucket_width.split()
-    pd_freq = f"{bw_val}{PANDAS_OFFSET_ALIASES[bw_unit]}"
+    pd_freq = f"{bucket_width_value}{PANDAS_OFFSET_ALIASES[bucket_width_unit]}"
 
     # Generate seconds per bucket (may not be constant due to variable size buckets)
-    seconds = gen_date_range(start_dt, end_dt, "1 second", timezone)
+    seconds = gen_date_range(start_dt, end_dt, 1, "second", timezone)
     nb_s_per_bucket = (
         pd.DataFrame({"count": 1}, index=seconds)
         .resample(pd_freq, closed="left", label="left")
@@ -35,7 +40,8 @@ def compute_completeness(
         end_dt,
         timeseries,
         data_state,
-        bucket_width,
+        bucket_width_value,
+        bucket_width_unit,
         "count",
         timezone=timezone,
     )

--- a/tests/analysis/test_completeness.py
+++ b/tests/analysis/test_completeness.py
@@ -93,7 +93,8 @@ class TestCompleteness:
                     dt.datetime(2020, 2, 1, tzinfo=dt.timezone.utc),
                 ],
                 "timeseries": {
-                    "Timeseries 0": {
+                    1: {
+                        "name": "Timeseries 0",
                         "avg_count": 4320.0,
                         "avg_ratio": 1.0,
                         "count": [4464, 4176],
@@ -103,7 +104,8 @@ class TestCompleteness:
                         "total_count": 8640,
                         "undefined_interval": False,
                     },
-                    "Timeseries 1": {
+                    2: {
+                        "name": "Timeseries 1",
                         "avg_count": 3846.5,
                         "avg_ratio": 0.8939292114695341,
                         "count": [3517, 4176],
@@ -113,7 +115,8 @@ class TestCompleteness:
                         "total_count": 7693,
                         "undefined_interval": False,
                     },
-                    "Timeseries 2": {
+                    3: {
+                        "name": "Timeseries 2",
                         "avg_count": 6028.0,
                         "avg_ratio": 2.790739710789766,
                         "count": [6229, 5827],
@@ -123,7 +126,8 @@ class TestCompleteness:
                         "total_count": 12056,
                         "undefined_interval": False,
                     },
-                    "Timeseries 3": {
+                    4: {
+                        "name": "Timeseries 3",
                         "avg_count": 4672.0,
                         "avg_ratio": 0.782314808151154,
                         "count": [3517, 5827],
@@ -133,7 +137,8 @@ class TestCompleteness:
                         "total_count": 9344,
                         "undefined_interval": True,
                     },
-                    "Timeseries 4": {
+                    5: {
+                        "name": "Timeseries 4",
                         "avg_count": 0.0,
                         "avg_ratio": None,
                         "count": [0, 0],
@@ -154,36 +159,36 @@ class TestCompleteness:
             assert ret["timestamps"][-1] == dt.datetime(
                 2020, 2, 29, tzinfo=dt.timezone.utc
             )
-            assert ret["timeseries"]["Timeseries 0"]["avg_count"] == 144.0
-            assert ret["timeseries"]["Timeseries 0"]["total_count"] == 8640
-            assert ret["timeseries"]["Timeseries 0"]["avg_ratio"] == 1.0
-            assert ret["timeseries"]["Timeseries 0"]["interval"] == 600.0
-            assert ret["timeseries"]["Timeseries 0"]["undefined_interval"] is False
-            assert ret["timeseries"]["Timeseries 0"]["expected_count"] == 60 * [144.0]
-            assert ret["timeseries"]["Timeseries 1"]["avg_count"] == 128.21666666666667
-            assert ret["timeseries"]["Timeseries 1"]["total_count"] == 7693
-            assert ret["timeseries"]["Timeseries 1"]["avg_ratio"] == 0.8903935185185186
-            assert ret["timeseries"]["Timeseries 1"]["interval"] == 600.0
-            assert ret["timeseries"]["Timeseries 1"]["undefined_interval"] is False
-            assert ret["timeseries"]["Timeseries 1"]["expected_count"] == 60 * [144.0]
-            assert ret["timeseries"]["Timeseries 2"]["avg_count"] == 200.93333333333334
-            assert ret["timeseries"]["Timeseries 2"]["total_count"] == 12056
-            assert ret["timeseries"]["Timeseries 2"]["avg_ratio"] == 2.79074074074074
-            assert ret["timeseries"]["Timeseries 2"]["interval"] == 1200.0
-            assert ret["timeseries"]["Timeseries 2"]["undefined_interval"] is False
-            assert ret["timeseries"]["Timeseries 2"]["expected_count"] == 60 * [72.0]
-            assert ret["timeseries"]["Timeseries 3"]["avg_count"] == 155.73333333333332
-            assert ret["timeseries"]["Timeseries 3"]["total_count"] == 9344
-            assert ret["timeseries"]["Timeseries 3"]["avg_ratio"] == 0.7747927031509121
-            assert ret["timeseries"]["Timeseries 3"]["interval"] == 429.85074626865674
-            assert ret["timeseries"]["Timeseries 3"]["undefined_interval"] is True
-            assert ret["timeseries"]["Timeseries 3"]["expected_count"] == 60 * [201.0]
-            assert ret["timeseries"]["Timeseries 4"]["avg_count"] == 0.0
-            assert ret["timeseries"]["Timeseries 4"]["total_count"] == 0
-            assert ret["timeseries"]["Timeseries 4"]["avg_ratio"] is None
-            assert ret["timeseries"]["Timeseries 4"]["interval"] is None
-            assert ret["timeseries"]["Timeseries 4"]["undefined_interval"] is True
-            assert ret["timeseries"]["Timeseries 4"]["expected_count"] == 60 * [None]
+            assert ret["timeseries"][1]["avg_count"] == 144.0
+            assert ret["timeseries"][1]["total_count"] == 8640
+            assert ret["timeseries"][1]["avg_ratio"] == 1.0
+            assert ret["timeseries"][1]["interval"] == 600.0
+            assert ret["timeseries"][1]["undefined_interval"] is False
+            assert ret["timeseries"][1]["expected_count"] == 60 * [144.0]
+            assert ret["timeseries"][2]["avg_count"] == 128.21666666666667
+            assert ret["timeseries"][2]["total_count"] == 7693
+            assert ret["timeseries"][2]["avg_ratio"] == 0.8903935185185186
+            assert ret["timeseries"][2]["interval"] == 600.0
+            assert ret["timeseries"][2]["undefined_interval"] is False
+            assert ret["timeseries"][2]["expected_count"] == 60 * [144.0]
+            assert ret["timeseries"][3]["avg_count"] == 200.93333333333334
+            assert ret["timeseries"][3]["total_count"] == 12056
+            assert ret["timeseries"][3]["avg_ratio"] == 2.79074074074074
+            assert ret["timeseries"][3]["interval"] == 1200.0
+            assert ret["timeseries"][3]["undefined_interval"] is False
+            assert ret["timeseries"][3]["expected_count"] == 60 * [72.0]
+            assert ret["timeseries"][4]["avg_count"] == 155.73333333333332
+            assert ret["timeseries"][4]["total_count"] == 9344
+            assert ret["timeseries"][4]["avg_ratio"] == 0.7747927031509121
+            assert ret["timeseries"][4]["interval"] == 429.85074626865674
+            assert ret["timeseries"][4]["undefined_interval"] is True
+            assert ret["timeseries"][4]["expected_count"] == 60 * [201.0]
+            assert ret["timeseries"][5]["avg_count"] == 0.0
+            assert ret["timeseries"][5]["total_count"] == 0
+            assert ret["timeseries"][5]["avg_ratio"] is None
+            assert ret["timeseries"][5]["interval"] is None
+            assert ret["timeseries"][5]["undefined_interval"] is True
+            assert ret["timeseries"][5]["expected_count"] == 60 * [None]
 
             # 2 months - weekly
             ret = compute_completeness(start_dt, end_dt, ts_l, ds_1, "1 week")
@@ -193,7 +198,7 @@ class TestCompleteness:
             assert ret["timestamps"][-1] == dt.datetime(
                 2020, 2, 24, tzinfo=dt.timezone.utc
             )
-            assert ret["timeseries"]["Timeseries 0"]["count"] == [
+            assert ret["timeseries"][1]["count"] == [
                 720,
                 1008,
                 1008,
@@ -204,8 +209,8 @@ class TestCompleteness:
                 1008,
                 864,
             ]
-            assert ret["timeseries"]["Timeseries 0"]["avg_ratio"] == 1.0
-            assert ret["timeseries"]["Timeseries 2"]["count"] == [
+            assert ret["timeseries"][1]["avg_ratio"] == 1.0
+            assert ret["timeseries"][3]["count"] == [
                 1005,
                 1407,
                 1406,
@@ -216,7 +221,7 @@ class TestCompleteness:
                 1407,
                 1205,
             ]
-            assert ret["timeseries"]["Timeseries 3"]["count"] == [
+            assert ret["timeseries"][4]["count"] == [
                 720,
                 1008,
                 1008,
@@ -238,27 +243,21 @@ class TestCompleteness:
             assert ret["timestamps"][-1] == dt.datetime(
                 2020, 1, 1, 23, 59, tzinfo=dt.timezone.utc
             )
-            assert ret["timeseries"]["Timeseries 0"]["avg_count"] == 0.1
-            assert ret["timeseries"]["Timeseries 0"]["total_count"] == 6 * 24
-            assert ret["timeseries"]["Timeseries 0"]["avg_ratio"] == 1.0
-            assert ret["timeseries"]["Timeseries 0"]["interval"] == 600.0
-            assert ret["timeseries"]["Timeseries 0"]["undefined_interval"] is False
-            assert ret["timeseries"]["Timeseries 0"]["expected_count"] == 60 * 24 * [
-                0.1
-            ]
-            assert ret["timeseries"]["Timeseries 2"]["avg_count"] == 0.13958333333333334
-            assert ret["timeseries"]["Timeseries 2"]["total_count"] == 201
-            assert ret["timeseries"]["Timeseries 2"]["avg_ratio"] == 2.7916666666666665
-            assert ret["timeseries"]["Timeseries 2"]["interval"] == 1200.0
-            assert ret["timeseries"]["Timeseries 2"]["undefined_interval"] is False
-            assert ret["timeseries"]["Timeseries 2"]["expected_count"] == 24 * 60 * [
-                0.05
-            ]
-            assert ret["timeseries"]["Timeseries 4"]["avg_count"] == 0.0
-            assert ret["timeseries"]["Timeseries 4"]["total_count"] == 0
-            assert ret["timeseries"]["Timeseries 4"]["avg_ratio"] is None
-            assert ret["timeseries"]["Timeseries 4"]["interval"] is None
-            assert ret["timeseries"]["Timeseries 4"]["undefined_interval"] is True
-            assert ret["timeseries"]["Timeseries 4"]["expected_count"] == 24 * 60 * [
-                None
-            ]
+            assert ret["timeseries"][1]["avg_count"] == 0.1
+            assert ret["timeseries"][1]["total_count"] == 6 * 24
+            assert ret["timeseries"][1]["avg_ratio"] == 1.0
+            assert ret["timeseries"][1]["interval"] == 600.0
+            assert ret["timeseries"][1]["undefined_interval"] is False
+            assert ret["timeseries"][1]["expected_count"] == 60 * 24 * [0.1]
+            assert ret["timeseries"][3]["avg_count"] == 0.13958333333333334
+            assert ret["timeseries"][3]["total_count"] == 201
+            assert ret["timeseries"][3]["avg_ratio"] == 2.7916666666666665
+            assert ret["timeseries"][3]["interval"] == 1200.0
+            assert ret["timeseries"][3]["undefined_interval"] is False
+            assert ret["timeseries"][3]["expected_count"] == 24 * 60 * [0.05]
+            assert ret["timeseries"][5]["avg_count"] == 0.0
+            assert ret["timeseries"][5]["total_count"] == 0
+            assert ret["timeseries"][5]["avg_ratio"] is None
+            assert ret["timeseries"][5]["interval"] is None
+            assert ret["timeseries"][5]["undefined_interval"] is True
+            assert ret["timeseries"][5]["expected_count"] == 24 * 60 * [None]

--- a/tests/analysis/test_completeness.py
+++ b/tests/analysis/test_completeness.py
@@ -86,7 +86,7 @@ class TestCompleteness:
             ts_l = (ts_0, ts_1, ts_2, ts_3, ts_4)
 
             # 2 months - monthly
-            ret = compute_completeness(start_dt, end_dt, ts_l, ds_1, "1 month")
+            ret = compute_completeness(start_dt, end_dt, ts_l, ds_1, 1, "month")
             assert ret == {
                 "timestamps": [
                     dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
@@ -152,7 +152,7 @@ class TestCompleteness:
             }
 
             # 2 months - daily
-            ret = compute_completeness(start_dt, end_dt, ts_l, ds_1, "1 day")
+            ret = compute_completeness(start_dt, end_dt, ts_l, ds_1, 1, "day")
             assert ret["timestamps"][0] == dt.datetime(
                 2020, 1, 1, tzinfo=dt.timezone.utc
             )
@@ -191,7 +191,7 @@ class TestCompleteness:
             assert ret["timeseries"][5]["expected_count"] == 60 * [None]
 
             # 2 months - weekly
-            ret = compute_completeness(start_dt, end_dt, ts_l, ds_1, "1 week")
+            ret = compute_completeness(start_dt, end_dt, ts_l, ds_1, 1, "week")
             assert ret["timestamps"][0] == dt.datetime(
                 2019, 12, 30, tzinfo=dt.timezone.utc
             )
@@ -235,7 +235,7 @@ class TestCompleteness:
 
             # 1 day - minute step
             ret = compute_completeness(
-                start_dt, start_dt_plus_1_day, ts_l, ds_1, "1 minute"
+                start_dt, start_dt_plus_1_day, ts_l, ds_1, 1, "minute"
             )
             assert ret["timestamps"][0] == dt.datetime(
                 2020, 1, 1, tzinfo=dt.timezone.utc

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -19,6 +19,7 @@ from bemserver_core.database import db
 from bemserver_core.authorization import CurrentUser, OpenBar
 from bemserver_core.exceptions import (
     BEMServerAuthorizationError,
+    TimeseriesDataIOInvalidBucketWidthError,
     TimeseriesDataIOInvalidAggregationError,
     TimeseriesDataCSVIOError,
     TimeseriesNotFoundError,
@@ -352,7 +353,8 @@ class TestTimeseriesDataIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "count",
                 col_label="name",
             )
@@ -383,7 +385,8 @@ class TestTimeseriesDataIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "2 day",
+                2,
+                "day",
                 "count",
                 col_label="name",
             )
@@ -413,7 +416,8 @@ class TestTimeseriesDataIO:
                 end_dt + dt.timedelta(days=3),
                 ts_l,
                 ds_1,
-                "2 day",
+                2,
+                "day",
                 "count",
                 col_label="name",
             )
@@ -444,7 +448,8 @@ class TestTimeseriesDataIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "count",
                 col_label="name",
             )
@@ -476,7 +481,8 @@ class TestTimeseriesDataIO:
                 dt.datetime(2020, 1, 9, tzinfo=ZoneInfo("Europe/Paris")),
                 ts_l,
                 ds_1,
-                "1 week",
+                1,
+                "week",
                 "count",
                 col_label="name",
                 timezone="Europe/Paris",
@@ -507,7 +513,8 @@ class TestTimeseriesDataIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "12 hour",
+                12,
+                "hour",
                 "count",
                 col_label="name",
             )
@@ -540,7 +547,8 @@ class TestTimeseriesDataIO:
                 end_dt.replace(tzinfo=ZoneInfo("Europe/Paris")),
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 timezone="Europe/Paris",
                 col_label="name",
             )
@@ -571,7 +579,8 @@ class TestTimeseriesDataIO:
                 end_dt + dt.timedelta(days=1),
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "sum",
                 col_label="name",
             )
@@ -603,7 +612,8 @@ class TestTimeseriesDataIO:
                 end_dt + dt.timedelta(days=1),
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "min",
                 col_label="name",
             )
@@ -635,7 +645,8 @@ class TestTimeseriesDataIO:
                 end_dt + dt.timedelta(days=1),
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "max",
                 col_label="name",
             )
@@ -667,7 +678,8 @@ class TestTimeseriesDataIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "count",
                 col_label="id",
             )
@@ -698,8 +710,31 @@ class TestTimeseriesDataIO:
                     end_dt,
                     ts_l,
                     ds_1,
-                    "1 day",
-                    "lol",
+                    1,
+                    "day",
+                    "dummy",
+                )
+
+            with pytest.raises(TimeseriesDataIOInvalidBucketWidthError):
+                tsdio.get_timeseries_buckets_data(
+                    start_dt,
+                    end_dt,
+                    ts_l,
+                    ds_1,
+                    -1,
+                    "day",
+                    "avg",
+                )
+
+            with pytest.raises(TimeseriesDataIOInvalidBucketWidthError):
+                tsdio.get_timeseries_buckets_data(
+                    start_dt,
+                    end_dt,
+                    ts_l,
+                    ds_1,
+                    1,
+                    "dummy",
+                    "avg",
                 )
 
     def test_timeseries_data_io_get_timeseries_buckets_data_fixed_size_dst_as_admin(
@@ -742,7 +777,7 @@ class TestTimeseriesDataIO:
 
         with CurrentUser(admin_user):
 
-            args = [(ts_0,), ds_1, "1 day", "count"]
+            args = [(ts_0,), ds_1, 1, "day", "count"]
             kwargs = {"timezone": "Europe/Paris", "col_label": "name"}
 
             # local TZ count 1 day - Spring forward
@@ -800,7 +835,7 @@ class TestTimeseriesDataIO:
 
             # Export CSV: UTC count year
             data_df = tsdio.get_timeseries_buckets_data(
-                start_dt, end_dt, ts_l, ds_1, "1 year", "count", col_label="name"
+                start_dt, end_dt, ts_l, ds_1, 1, "year", "count", col_label="name"
             )
 
             index = pd.DatetimeIndex(
@@ -828,7 +863,8 @@ class TestTimeseriesDataIO:
                 end_dt + dt.timedelta(days=100),
                 ts_l,
                 ds_1,
-                "1 year",
+                1,
+                "year",
                 "count",
                 col_label="name",
             )
@@ -855,7 +891,7 @@ class TestTimeseriesDataIO:
 
             # Export CSV: UTC count 2 year
             data_df = tsdio.get_timeseries_buckets_data(
-                start_dt, end_dt, ts_l, ds_1, "2 year", "count", col_label="name"
+                start_dt, end_dt, ts_l, ds_1, 2, "year", "count", col_label="name"
             )
 
             index = pd.DatetimeIndex(
@@ -882,7 +918,8 @@ class TestTimeseriesDataIO:
                 end_dt.replace(tzinfo=ZoneInfo("Europe/Paris")),
                 ts_l,
                 ds_1,
-                "1 year",
+                1,
+                "year",
                 "count",
                 timezone="Europe/Paris",
                 col_label="name",
@@ -924,7 +961,8 @@ class TestTimeseriesDataIO:
                 start_dt_plus_3_months,
                 ts_l,
                 ds_1,
-                "1 month",
+                1,
+                "month",
                 "avg",
                 col_label="name",
             )
@@ -957,7 +995,8 @@ class TestTimeseriesDataIO:
                 start_dt_plus_3_months,
                 ts_l,
                 ds_1,
-                "1 month",
+                1,
+                "month",
                 "avg",
                 col_label="name",
             )
@@ -988,7 +1027,8 @@ class TestTimeseriesDataIO:
                 start_dt_plus_3_months,
                 ts_l,
                 ds_1,
-                "2 month",
+                2,
+                "month",
                 "avg",
                 col_label="name",
             )
@@ -1018,7 +1058,8 @@ class TestTimeseriesDataIO:
                 start_dt_plus_3_months,
                 ts_l,
                 ds_1,
-                "1 month",
+                1,
+                "month",
                 "avg",
                 timezone="Europe/Paris",
                 col_label="name",
@@ -1051,7 +1092,8 @@ class TestTimeseriesDataIO:
                 start_dt_plus_3_months,
                 ts_l,
                 ds_1,
-                "1 month",
+                1,
+                "month",
                 "sum",
                 col_label="name",
             )
@@ -1082,7 +1124,8 @@ class TestTimeseriesDataIO:
                 start_dt_plus_3_months,
                 ts_l,
                 ds_1,
-                "1 month",
+                1,
+                "month",
                 "min",
                 col_label="name",
             )
@@ -1113,7 +1156,8 @@ class TestTimeseriesDataIO:
                 start_dt_plus_3_months,
                 ts_l,
                 ds_1,
-                "1 month",
+                1,
+                "month",
                 "max",
                 col_label="name",
             )
@@ -1140,7 +1184,7 @@ class TestTimeseriesDataIO:
 
             # Export CSV: UTC count year by ID
             data_df = tsdio.get_timeseries_buckets_data(
-                start_dt, end_dt, ts_l, ds_1, "1 year", "count", col_label="id"
+                start_dt, end_dt, ts_l, ds_1, 1, "year", "count", col_label="id"
             )
 
             index = pd.DatetimeIndex(
@@ -1167,7 +1211,7 @@ class TestTimeseriesDataIO:
     @pytest.mark.usefixtures("user_groups_by_campaigns")
     @pytest.mark.usefixtures("user_groups_by_campaign_scopes")
     @pytest.mark.parametrize("col_label", ("id", "name"))
-    def test_timeseries_data_io_export_csv_bucket_as_user(
+    def test_timeseries_data_io_get_timeseries_buckets_data_as_user(
         self, users, timeseries, col_label
     ):
         user_1 = users[1]
@@ -1198,7 +1242,7 @@ class TestTimeseriesDataIO:
 
             with pytest.raises(BEMServerAuthorizationError):
                 tsdio.get_timeseries_buckets_data(
-                    start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+                    start_dt, end_dt, ts_l, ds_1, 1, "day", col_label=col_label
                 )
 
             # Export CSV: UTC avg
@@ -1206,7 +1250,7 @@ class TestTimeseriesDataIO:
             ts_l = (ts_1, ts_3)
 
             data_df = tsdio.get_timeseries_buckets_data(
-                start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+                start_dt, end_dt, ts_l, ds_1, 1, "day", col_label=col_label
             )
 
             index = pd.DatetimeIndex(
@@ -1643,7 +1687,7 @@ class TestTimeseriesDataCSVIO:
 
             # Export CSV: UTC avg
             data = tsdcsvio.export_csv_bucket(
-                start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+                start_dt, end_dt, ts_l, ds_1, 1, "day", col_label=col_label
             )
             assert data == header + (
                 "2020-01-01T00:00:00+0000,11.5,,33.0\n"
@@ -1657,7 +1701,8 @@ class TestTimeseriesDataCSVIO:
                 end_dt.replace(tzinfo=ZoneInfo("Europe/Paris")),
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 timezone="Europe/Paris",
                 col_label=col_label,
             )
@@ -1673,7 +1718,8 @@ class TestTimeseriesDataCSVIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "sum",
                 col_label=col_label,
             )
@@ -1689,7 +1735,8 @@ class TestTimeseriesDataCSVIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "min",
                 col_label=col_label,
             )
@@ -1705,7 +1752,8 @@ class TestTimeseriesDataCSVIO:
                 end_dt,
                 ts_l,
                 ds_1,
-                "1 day",
+                1,
+                "day",
                 "max",
                 col_label=col_label,
             )
@@ -1722,7 +1770,8 @@ class TestTimeseriesDataCSVIO:
                     end_dt,
                     ts_l,
                     ds_1,
-                    "1 day",
+                    1,
+                    "day",
                     "lol",
                     col_label=col_label,
                 )
@@ -1763,7 +1812,7 @@ class TestTimeseriesDataCSVIO:
 
             with pytest.raises(BEMServerAuthorizationError):
                 data = tsdcsvio.export_csv_bucket(
-                    start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+                    start_dt, end_dt, ts_l, ds_1, 1, "day", col_label=col_label
                 )
 
             # Export CSV: UTC avg
@@ -1776,7 +1825,7 @@ class TestTimeseriesDataCSVIO:
             ts_l = (ts_1, ts_3)
 
             data = tsdcsvio.export_csv_bucket(
-                start_dt, end_dt, ts_l, ds_1, "1 day", col_label=col_label
+                start_dt, end_dt, ts_l, ds_1, 1, "day", col_label=col_label
             )
             assert data == header + (
                 "2020-01-01T00:00:00+0000,11.5,33.0\n"


### PR DESCRIPTION
- `col_label` defaults to `"id"`
- completeness: use TS ID as key, return name in payload
- split `bucket_width` argument into `bucket_width_value` and `bucket_width_unit`