### PR TITLE
Remove use of python-dotenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,6 @@ Set DB URI in an evironment variable::
 
 $ EXPORT SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://user:password@localhost:5432/bemserver"
 
-Alternatively, in development mode, one may write this env var in a .env file
-and install python-dotenv to load it.
-
 
 Development mode
 ----------------

--- a/bemserver_core/commands.py
+++ b/bemserver_core/commands.py
@@ -11,14 +11,6 @@ from bemserver_core.exceptions import BEMServerCoreError
 
 
 def _set_db_url():
-    # Allow the use of a .env file to store SQLALCHEMY_DATABASE_URI environment variable
-    try:
-        from dotenv import load_dotenv
-    except ImportError:
-        pass
-    else:
-        load_dotenv()
-
     db_url = os.getenv("SQLALCHEMY_DATABASE_URI")
     if db_url is None:
         raise BEMServerCoreError("SQLALCHEMY_DATABASE_URI environment variable not set")

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -11,15 +11,6 @@ from alembic import context
 from bemserver_core.database import db, Base
 
 
-# Allow the use of a .env file to store SQLALCHEMY_DATABASE_URI environment variable
-try:
-    from dotenv import load_dotenv
-except ImportError:
-    pass
-else:
-    load_dotenv()
-
-
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config


### PR DESCRIPTION
dotenv only works in dev mode with current directory being the repository. It will fail when using the command from another directory or if bemserver-core is installed not in dev mode, making the command pretty much worthless.

Better to instruct the user to set the environment variable correctly.