### PR TITLE
Fix DBConnection: remove existing sessions when setting DB_URL

### DIFF
--- a/bemserver_core/database.py
+++ b/bemserver_core/database.py
@@ -170,6 +170,8 @@ class DBConnection:
             future=True,
         )
         SESSION_FACTORY.configure(bind=self.engine)
+        # Remove any existing session from registry
+        DB_SESSION.remove()
 
     @property
     def session(self):


### PR DESCRIPTION
The issue only affects use cases calling `set_db_url` several times with a different URL.

In practice this may happens in tests. In fact, I got caught by this while writing tests.