### PR TITLE
Add "inclusive" argument to TimeseriesDataIO.get_timeseries_data and cleanup process

### DIFF
--- a/bemserver_core/process/cleanup.py
+++ b/bemserver_core/process/cleanup.py
@@ -13,6 +13,8 @@ def cleanup(
     end_dt,
     timeseries,
     data_state,
+    *,
+    inclusive="left",
 ):
     """Cleanup process
 
@@ -27,6 +29,7 @@ def cleanup(
         end_dt,
         timeseries,
         data_state,
+        inclusive=inclusive,
     )
 
     # Get min/max properties values for each TS

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -204,9 +204,10 @@ class TestTimeseriesDataIO:
                 tsdio.set_timeseries_data(data_df, ds_1, campaign)
 
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
-    @pytest.mark.parametrize("col_label", ("id", "name"))
     def test_timeseries_data_io_get_timeseries_data_as_admin(
-        self, users, timeseries, col_label
+        self,
+        users,
+        timeseries,
     ):
         admin_user = users[0]
         assert admin_user.is_admin
@@ -222,19 +223,15 @@ class TestTimeseriesDataIO:
         h2_dt = start_dt + dt.timedelta(hours=2)
         end_dt = start_dt + dt.timedelta(hours=3)
 
-        # No data
+        # No data (by col name)
         with CurrentUser(admin_user):
             ts_l = (ts_0, ts_2, ts_4)
             data_df = tsdio.get_timeseries_data(
-                start_dt, end_dt, ts_l, ds_1, col_label=col_label
+                start_dt, end_dt, ts_l, ds_1, col_label="name"
             )
             index = pd.DatetimeIndex([], name="timestamp", tz="UTC")
             no_data_df = pd.DataFrame(
-                {
-                    ts_0.name if col_label == "name" else ts_0.id: [],
-                    ts_2.name if col_label == "name" else ts_2.id: [],
-                    ts_4.name if col_label == "name" else ts_4.id: [],
-                },
+                {ts_0.name: [], ts_2.name: [], ts_4.name: []},
                 index=index,
             )
             assert data_df.equals(no_data_df)
@@ -252,9 +249,7 @@ class TestTimeseriesDataIO:
 
             ts_l = (ts_0, ts_2, ts_4)
 
-            data_df = tsdio.get_timeseries_data(
-                start_dt, end_dt, ts_l, ds_1, col_label=col_label
-            )
+            data_df = tsdio.get_timeseries_data(start_dt, end_dt, ts_l, ds_1)
             index = pd.DatetimeIndex(
                 [
                     "2020-01-01T00:00:00+00:00",
@@ -268,36 +263,26 @@ class TestTimeseriesDataIO:
             val_2 = [np.nan, np.nan, np.nan]
             val_4 = [10.0, 12.0, np.nan]
             expected_data_df = pd.DataFrame(
-                {
-                    ts_0.name if col_label == "name" else ts_0.id: val_0,
-                    ts_2.name if col_label == "name" else ts_2.id: val_2,
-                    ts_4.name if col_label == "name" else ts_4.id: val_4,
-                },
+                {ts_0.id: val_0, ts_2.id: val_2, ts_4.id: val_4},
                 index=index,
             )
             assert data_df.equals(expected_data_df)
 
             # Get with no start_date
-            data_df = tsdio.get_timeseries_data(
-                None, end_dt, ts_l, ds_1, col_label=col_label
-            )
+            data_df = tsdio.get_timeseries_data(None, end_dt, ts_l, ds_1)
             assert data_df.equals(expected_data_df)
 
             # Get with no end date
-            data_df = tsdio.get_timeseries_data(
-                start_dt, None, ts_l, ds_1, col_label=col_label
-            )
+            data_df = tsdio.get_timeseries_data(start_dt, None, ts_l, ds_1)
             assert data_df.equals(expected_data_df)
 
             # Get with no start/end date
-            data_df = tsdio.get_timeseries_data(
-                None, None, ts_l, ds_1, col_label=col_label
-            )
+            data_df = tsdio.get_timeseries_data(None, None, ts_l, ds_1)
             assert data_df.equals(expected_data_df)
 
             # Get outside data range: no data
             data_df = tsdio.get_timeseries_data(
-                end_dt, None, ts_l, ds_1, col_label=col_label
+                end_dt, None, ts_l, ds_1, col_label="name"
             )
             assert data_df.equals(no_data_df)
 
@@ -308,7 +293,6 @@ class TestTimeseriesDataIO:
                 ts_l,
                 ds_1,
                 timezone="Europe/Paris",
-                col_label=col_label,
             )
             expected_data_df.index = pd.DatetimeIndex(
                 [
@@ -334,29 +318,25 @@ class TestTimeseriesDataIO:
             val_2 = [np.nan, np.nan]
             val_4 = [12.0, np.nan]
             expected_data_df = pd.DataFrame(
-                {
-                    ts_0.name if col_label == "name" else ts_0.id: val_0,
-                    ts_2.name if col_label == "name" else ts_2.id: val_2,
-                    ts_4.name if col_label == "name" else ts_4.id: val_4,
-                },
+                {ts_0.id: val_0, ts_2.id: val_2, ts_4.id: val_4},
                 index=index,
             )
             data_df = tsdio.get_timeseries_data(
-                h1_dt, h2_dt, ts_l, ds_1, inclusive="both", col_label=col_label
+                h1_dt, h2_dt, ts_l, ds_1, inclusive="both"
             )
             assert data_df.equals(expected_data_df)
             data_df = tsdio.get_timeseries_data(
-                h1_dt, h2_dt, ts_l, ds_1, inclusive="neither", col_label=col_label
+                h1_dt, h2_dt, ts_l, ds_1, inclusive="neither"
             )
             mask = (expected_data_df.index > h1_dt) & (expected_data_df.index < h2_dt)
             assert data_df.equals(expected_data_df.loc[mask])
             data_df = tsdio.get_timeseries_data(
-                h1_dt, h2_dt, ts_l, ds_1, inclusive="left", col_label=col_label
+                h1_dt, h2_dt, ts_l, ds_1, inclusive="left"
             )
             mask = (expected_data_df.index >= h1_dt) & (expected_data_df.index < h2_dt)
             assert data_df.equals(expected_data_df.loc[mask])
             data_df = tsdio.get_timeseries_data(
-                h1_dt, h2_dt, ts_l, ds_1, inclusive="right", col_label=col_label
+                h1_dt, h2_dt, ts_l, ds_1, inclusive="right"
             )
             mask = (expected_data_df.index > h1_dt) & (expected_data_df.index <= h2_dt)
             assert data_df.equals(expected_data_df.loc[mask])

--- a/tests/process/test_cleanup.py
+++ b/tests/process/test_cleanup.py
@@ -17,9 +17,9 @@ from bemserver_core.authorization import CurrentUser, OpenBar
 from bemserver_core.process.cleanup import cleanup
 
 
-class TestCleanup:
+class TestCleanupProcess:
     @pytest.mark.parametrize("timeseries", (4,), indirect=True)
-    def test_cleanup(self, users, timeseries):
+    def test_cleanup_process(self, users, timeseries):
         admin_user = users[0]
         assert admin_user.is_admin
         # Min/Max
@@ -64,21 +64,21 @@ class TestCleanup:
 
         start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
         end_dt = dt.datetime(2020, 1, 2, tzinfo=dt.timezone.utc)
-        timestamps = pd.date_range(start_dt, end_dt, inclusive="left", freq="6H")
-        values = [0, 13, 33, 69]
+        timestamps = pd.date_range(start_dt, end_dt, inclusive="both", freq="6H")
+        values = [0, 13, 33, 42, 69]
         create_timeseries_data(ts_0, ds_1, timestamps, values)
         create_timeseries_data(ts_1, ds_1, timestamps, values)
         create_timeseries_data(ts_2, ds_1, timestamps, values)
 
         with CurrentUser(admin_user):
             ts_l = (ts_0, ts_1, ts_2, ts_3)
-            ret = cleanup(start_dt, end_dt, ts_l, ds_1)
+            ret = cleanup(start_dt, end_dt, ts_l, ds_1, inclusive="both")
             expected = pd.DataFrame(
                 {
-                    ts_0.id: [np.nan, 13, 33, np.nan],
-                    ts_1.id: [np.nan, 13, 33, 69],
-                    ts_2.id: [0, 13, 33, 69],
-                    ts_3.id: [np.nan, np.nan, np.nan, np.nan],
+                    ts_0.id: [np.nan, 13, 33, 42, np.nan],
+                    ts_1.id: [np.nan, 13, 33, 42, 69],
+                    ts_2.id: [0, 13, 33, 42, 69],
+                    ts_3.id: [np.nan, np.nan, np.nan, np.nan, np.nan],
                 },
                 index=pd.DatetimeIndex(timestamps, name="timestamp"),
                 dtype=float,


### PR DESCRIPTION
`inclusive` is copied from Pandas (e.g. https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.date_range.html)

The point is to allow including/excluding bounds when querying timeseries data, more specifically to exclude `start_dt` from cleanup when scheduling a cleanup, since `start_dt` is the last timestamp from last execution, therefore it is already processed.

Also, rework tests to remove `col_label` parameter to avoid doing the whole test twice. Only test `col_label=name` once rather than parametrize the whole test function.