### PR TITLE
Improve cleanup service model

### DIFF
--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -27,6 +27,7 @@ from bemserver_core.exceptions import (
 
 
 class TestTimeseriesDataIO:
+    @pytest.mark.parametrize("campaigns", (2,), indirect=True)
     @pytest.mark.parametrize("timeseries", (3,), indirect=True)
     @pytest.mark.parametrize("for_campaign", (True, False))
     def test_timeseries_data_io_set_timeseries_data_as_admin(
@@ -341,6 +342,7 @@ class TestTimeseriesDataIO:
             mask = (expected_data_df.index > h1_dt) & (expected_data_df.index <= h2_dt)
             assert data_df.equals(expected_data_df.loc[mask])
 
+    @pytest.mark.parametrize("campaigns", (2,), indirect=True)
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
     @pytest.mark.usefixtures("user_groups_by_campaigns")
@@ -1292,6 +1294,7 @@ class TestTimeseriesDataIO:
 
             assert data_df.equals(expected_data_df)
 
+    @pytest.mark.parametrize("campaigns", (2,), indirect=True)
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
     @pytest.mark.usefixtures("user_groups_by_campaigns")
@@ -1391,6 +1394,7 @@ class TestTimeseriesDataIO:
             db.session.rollback()
             assert not db.session.query(TimeseriesData).all()
 
+    @pytest.mark.parametrize("campaigns", (2,), indirect=True)
     @pytest.mark.parametrize("timeseries", (4,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
     @pytest.mark.usefixtures("user_groups_by_campaigns")
@@ -1439,6 +1443,7 @@ class TestTimeseriesDataIO:
 
 
 class TestTimeseriesDataCSVIO:
+    @pytest.mark.parametrize("campaigns", (2,), indirect=True)
     @pytest.mark.parametrize("timeseries", (3,), indirect=True)
     @pytest.mark.parametrize("mode", ("str", "textiobase"))
     @pytest.mark.parametrize("for_campaign", (True, False))
@@ -1717,6 +1722,7 @@ class TestTimeseriesDataCSVIO:
                 "2020-01-01T03:00:00+0100,2.0,,\n"
             )
 
+    @pytest.mark.parametrize("campaigns", (2,), indirect=True)
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
     @pytest.mark.usefixtures("user_groups_by_campaigns")
@@ -1897,6 +1903,7 @@ class TestTimeseriesDataCSVIO:
                     col_label=col_label,
                 )
 
+    @pytest.mark.parametrize("campaigns", (2,), indirect=True)
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     @pytest.mark.usefixtures("users_by_user_groups")
     @pytest.mark.usefixtures("user_groups_by_campaigns")

--- a/tests/model/test_campaigns.py
+++ b/tests/model/test_campaigns.py
@@ -31,8 +31,8 @@ class TestCampaignModel:
         campaign_1 = campaigns[0]
 
         with CurrentUser(admin_user):
-            assert len(list(CampaignScope.get())) == 2
-            assert len(list(UserGroupByCampaign.get())) == 2
+            assert len(list(CampaignScope.get())) == 3
+            assert len(list(UserGroupByCampaign.get())) == 3
             assert len(list(Site.get())) == 2
             assert len(list(Building.get())) == 2
             assert len(list(Storey.get())) == 2
@@ -42,14 +42,24 @@ class TestCampaignModel:
 
             campaign_1.delete()
             db.session.commit()
-            assert len(list(CampaignScope.get())) == 1
-            assert len(list(UserGroupByCampaign.get())) == 1
+            assert len(list(CampaignScope.get())) == 2
+            assert len(list(UserGroupByCampaign.get())) == 2
             assert len(list(Site.get())) == 1
             assert len(list(Building.get())) == 1
             assert len(list(Storey.get())) == 1
             assert len(list(Space.get())) == 1
             assert len(list(Zone.get())) == 1
             assert len(list(Timeseries.get())) == 1
+
+    def test_campaign_get_in_name(self, users, campaigns):
+        admin_user = users[0]
+        campaign_1 = campaigns[0]
+
+        with CurrentUser(admin_user):
+            ret = Campaign.get(in_name=campaign_1.name[4:])
+            assert len(list(ret)) == 1
+            assert ret[0] == campaign_1
+            assert len(list(Campaign.get(in_name="toto"))) == 0
 
     def test_campaign_authorizations_as_admin(self, users):
         admin_user = users[0]
@@ -92,7 +102,7 @@ class TestCampaignModel:
 
             campaign = Campaign.get_by_id(campaign_2.id)
             campaigns = list(Campaign.get())
-            assert len(campaigns) == 1
+            assert len(campaigns) == 2
             assert campaigns[0].id == campaign_2.id
             with pytest.raises(BEMServerAuthorizationError):
                 Campaign.get_by_id(campaign_1.id)
@@ -149,7 +159,7 @@ class TestUserGroupByCampaignModel:
                 )
             ugbc = UserGroupByCampaign.get_by_id(ugbc_2.id)
             ugbcs = list(UserGroupByCampaign.get())
-            assert len(ugbcs) == 1
+            assert len(ugbcs) == 2
             assert ugbcs[0].id == ugbc_2.id
             with pytest.raises(BEMServerAuthorizationError):
                 UserGroupByCampaign.get_by_id(ugbc_1.id)
@@ -167,12 +177,12 @@ class TestCampaignScopeModel:
         cs_1 = campaign_scopes[0]
 
         with CurrentUser(admin_user):
-            assert len(list(UserGroupByCampaignScope.get())) == 2
+            assert len(list(UserGroupByCampaignScope.get())) == 3
             assert len(list(Timeseries.get())) == 2
 
             cs_1.delete()
             db.session.commit()
-            assert len(list(UserGroupByCampaignScope.get())) == 1
+            assert len(list(UserGroupByCampaignScope.get())) == 2
             assert len(list(Timeseries.get())) == 1
 
     @pytest.mark.usefixtures("as_admin")
@@ -244,7 +254,7 @@ class TestCampaignScopeModel:
 
             campaign_scope = CampaignScope.get_by_id(campaign_scope_2.id)
             campaign_scopes = list(CampaignScope.get())
-            assert len(campaign_scopes) == 1
+            assert len(campaign_scopes) == 2
             assert campaign_scopes[0].id == campaign_scope_2.id
             with pytest.raises(BEMServerAuthorizationError):
                 CampaignScope.get_by_id(campaign_scope_1.id)
@@ -301,7 +311,7 @@ class TestUserGroupByCampaignScopeModel:
                 )
             ugbcs = UserGroupByCampaignScope.get_by_id(ugbcs_2.id)
             ugbcss = list(UserGroupByCampaignScope.get())
-            assert len(ugbcss) == 1
+            assert len(ugbcss) == 2
             assert ugbcss[0].id == ugbcs_2.id
             with pytest.raises(BEMServerAuthorizationError):
                 UserGroupByCampaignScope.get_by_id(ugbcs_1.id)

--- a/tests/model/test_users.py
+++ b/tests/model/test_users.py
@@ -130,14 +130,14 @@ class TestUserGroupModel:
 
         with CurrentUser(admin_user):
             assert len(list(UserByUserGroup.get())) == 2
-            assert len(list(UserGroupByCampaign.get())) == 2
-            assert len(list(UserGroupByCampaignScope.get())) == 2
+            assert len(list(UserGroupByCampaign.get())) == 3
+            assert len(list(UserGroupByCampaignScope.get())) == 3
 
             user_group_1.delete()
             db.session.commit()
             assert len(list(UserByUserGroup.get())) == 1
-            assert len(list(UserGroupByCampaign.get())) == 1
-            assert len(list(UserGroupByCampaignScope.get())) == 1
+            assert len(list(UserGroupByCampaign.get())) == 2
+            assert len(list(UserGroupByCampaignScope.get())) == 2
 
     def test_user_group_authorizations_as_admin(self, users):
         admin_user = users[0]

--- a/tests/process/test_completeness.py
+++ b/tests/process/test_completeness.py
@@ -238,7 +238,7 @@ class TestCompleteness:
                 ],
                 "timeseries": {
                     1: {
-                        "name": "Timeseries 0",
+                        "name": "Timeseries 1",
                         "avg_count": 4320.0,
                         "avg_ratio": 1.0,
                         "count": [4464, 4176],
@@ -249,7 +249,7 @@ class TestCompleteness:
                         "undefined_interval": False,
                     },
                     2: {
-                        "name": "Timeseries 1",
+                        "name": "Timeseries 2",
                         "avg_count": 3846.5,
                         "avg_ratio": 0.8939292114695341,
                         "count": [3517, 4176],
@@ -260,7 +260,7 @@ class TestCompleteness:
                         "undefined_interval": False,
                     },
                     3: {
-                        "name": "Timeseries 2",
+                        "name": "Timeseries 3",
                         "avg_count": 6028.0,
                         "avg_ratio": 2.790739710789766,
                         "count": [6229, 5827],
@@ -271,7 +271,7 @@ class TestCompleteness:
                         "undefined_interval": False,
                     },
                     4: {
-                        "name": "Timeseries 3",
+                        "name": "Timeseries 4",
                         "avg_count": 4672.0,
                         "avg_ratio": 0.782314808151154,
                         "count": [3517, 5827],
@@ -282,7 +282,7 @@ class TestCompleteness:
                         "undefined_interval": True,
                     },
                     5: {
-                        "name": "Timeseries 4",
+                        "name": "Timeseries 5",
                         "avg_count": 0.0,
                         "avg_ratio": None,
                         "count": [0, 0],
@@ -423,17 +423,6 @@ class TestCompleteness:
                 ],
                 "timeseries": {
                     1: {
-                        "name": "Timeseries 0",
-                        "count": [6, 6, 3],
-                        "ratio": [1.0, 1.0, 1.0],
-                        "total_count": 15,
-                        "avg_count": 5.0,
-                        "avg_ratio": 1.0,
-                        "interval": 600.0,
-                        "undefined_interval": False,
-                        "expected_count": [6.0, 6.0, 3.0],
-                    },
-                    2: {
                         "name": "Timeseries 1",
                         "count": [6, 6, 3],
                         "ratio": [1.0, 1.0, 1.0],
@@ -444,8 +433,19 @@ class TestCompleteness:
                         "undefined_interval": False,
                         "expected_count": [6.0, 6.0, 3.0],
                     },
-                    3: {
+                    2: {
                         "name": "Timeseries 2",
+                        "count": [6, 6, 3],
+                        "ratio": [1.0, 1.0, 1.0],
+                        "total_count": 15,
+                        "avg_count": 5.0,
+                        "avg_ratio": 1.0,
+                        "interval": 600.0,
+                        "undefined_interval": False,
+                        "expected_count": [6.0, 6.0, 3.0],
+                    },
+                    3: {
+                        "name": "Timeseries 3",
                         "count": [8, 8, 5],
                         "ratio": [
                             2.6666666666666665,
@@ -460,7 +460,7 @@ class TestCompleteness:
                         "expected_count": [3.0, 3.0, 1.5],
                     },
                     4: {
-                        "name": "Timeseries 3",
+                        "name": "Timeseries 4",
                         "count": [6, 6, 3],
                         "ratio": [1.0, 1.0, 1.0],
                         "total_count": 15,
@@ -471,7 +471,7 @@ class TestCompleteness:
                         "expected_count": [6.0, 6.0, 3.0],
                     },
                     5: {
-                        "name": "Timeseries 4",
+                        "name": "Timeseries 5",
                         "count": [0, 0, 0],
                         "ratio": [None, None, None],
                         "total_count": 0,


### PR DESCRIPTION
This updates contains "get_all" methods that give cleanup service status (enabled and last timestamps) for all campaigns and timeseries.

Camaigns : get cleanup service state (enabled or not) even if this info is not in cleanup config datatable.
Timeseries : get last cleaned timestamp for each timeseries even if info is not in cleanup datatable (because added between 2 runs of cleaning...).