### PR TITLE
Shorten table and column names

### DIFF
--- a/bemserver_core/database.py
+++ b/bemserver_core/database.py
@@ -268,5 +268,5 @@ def make_columns_read_only(*fields):
     """
     for field in fields:
         db.session.execute(
-            _generate_ddl_trigger_read_only(field.class_.__table__, field.key)
+            _generate_ddl_trigger_read_only(field.class_.__table__, field.name)
         )

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -117,7 +117,7 @@ class TimeseriesDataIO:
 
         data_df = data_df.melt(
             value_vars=data_df.columns,
-            var_name="timeseries_by_data_state_id",
+            var_name="ts_by_data_state_id",
             ignore_index=False,
         )
         data_rows = [
@@ -309,7 +309,7 @@ class TimeseriesDataIO:
 
         query += (
             "FROM ts_data, timeseries, ts_by_data_states "
-            "WHERE ts_data.timeseries_by_data_state_id = "
+            "WHERE ts_data.ts_by_data_state_id = "
             "      ts_by_data_states.id "
             "  AND ts_by_data_states.data_state_id = :data_state_id "
             "  AND ts_by_data_states.timeseries_id = timeseries.id "

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -308,11 +308,11 @@ class TimeseriesDataIO:
             )
 
         query += (
-            "FROM timeseries_data, timeseries, timeseries_by_data_states "
-            "WHERE timeseries_data.timeseries_by_data_state_id = "
-            "      timeseries_by_data_states.id "
-            "  AND timeseries_by_data_states.data_state_id = :data_state_id "
-            "  AND timeseries_by_data_states.timeseries_id = timeseries.id "
+            "FROM ts_data, timeseries, ts_by_data_states "
+            "WHERE ts_data.timeseries_by_data_state_id = "
+            "      ts_by_data_states.id "
+            "  AND ts_by_data_states.data_state_id = :data_state_id "
+            "  AND ts_by_data_states.timeseries_id = timeseries.id "
             "  AND timeseries_id IN :timeseries_ids "
             "  AND timestamp >= :start_dt AND timestamp < :end_dt "
             "GROUP BY bucket, timeseries.id "

--- a/bemserver_core/model/campaigns.py
+++ b/bemserver_core/model/campaigns.py
@@ -31,7 +31,7 @@ class Campaign(AuthMixin, Base):
 
 
 class CampaignScope(AuthMixin, Base):
-    __tablename__ = "campaign_scopes"
+    __tablename__ = "c_scopes"
     __table_args__ = (sqla.UniqueConstraint("campaign_id", "name"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
@@ -62,12 +62,12 @@ class CampaignScope(AuthMixin, Base):
 class UserGroupByCampaign(AuthMixin, Base):
     """UserGroup x Campaign associations"""
 
-    __tablename__ = "user_groups_by_campaigns"
+    __tablename__ = "u_groups_by_campaigns"
     __table_args__ = (sqla.UniqueConstraint("campaign_id", "user_group_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     campaign_id = sqla.Column(sqla.ForeignKey("campaigns.id"), nullable=False)
-    user_group_id = sqla.Column(sqla.ForeignKey("user_groups.id"), nullable=False)
+    user_group_id = sqla.Column(sqla.ForeignKey("u_groups.id"), nullable=False)
 
     campaign = sqla.orm.relationship(
         Campaign,
@@ -100,14 +100,12 @@ class UserGroupByCampaign(AuthMixin, Base):
 class UserGroupByCampaignScope(AuthMixin, Base):
     """UserGroup x CampaignScope associations"""
 
-    __tablename__ = "user_groups_by_campaign_scopes"
+    __tablename__ = "u_groups_by_c_scopes"
     __table_args__ = (sqla.UniqueConstraint("campaign_scope_id", "user_group_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
-    campaign_scope_id = sqla.Column(
-        sqla.ForeignKey("campaign_scopes.id"), nullable=False
-    )
-    user_group_id = sqla.Column(sqla.ForeignKey("user_groups.id"), nullable=False)
+    campaign_scope_id = sqla.Column(sqla.ForeignKey("c_scopes.id"), nullable=False)
+    user_group_id = sqla.Column(sqla.ForeignKey("u_groups.id"), nullable=False)
 
     campaign_scope = sqla.orm.relationship(
         CampaignScope,

--- a/bemserver_core/model/energy.py
+++ b/bemserver_core/model/energy.py
@@ -6,27 +6,27 @@ from bemserver_core.authorization import AuthMixin, auth, Relation
 
 
 class EnergySource(AuthMixin, Base):
-    __tablename__ = "energy_sources"
+    __tablename__ = "ener_sources"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80), unique=True, nullable=False)
 
 
 class EnergyEndUse(AuthMixin, Base):
-    __tablename__ = "energy_end_uses"
+    __tablename__ = "ener_end_uses"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80), unique=True, nullable=False)
 
 
 class EnergyConsumptionTimeseriesBySite(AuthMixin, Base):
-    __tablename__ = "energy_consumption_ts_by_site"
+    __tablename__ = "ener_cons_ts_by_site"
     __table_args__ = (sqla.UniqueConstraint("site_id", "source_id", "end_use_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     site_id = sqla.Column(sqla.ForeignKey("sites.id"), nullable=False)
-    source_id = sqla.Column(sqla.ForeignKey("energy_sources.id"), nullable=False)
-    end_use_id = sqla.Column(sqla.ForeignKey("energy_end_uses.id"), nullable=False)
+    source_id = sqla.Column(sqla.ForeignKey("ener_sources.id"), nullable=False)
+    end_use_id = sqla.Column(sqla.ForeignKey("ener_end_uses.id"), nullable=False)
     timeseries_id = sqla.Column(sqla.ForeignKey("timeseries.id"), nullable=False)
     # Multiply TS values by wh_conversion_factor to get Wh
     wh_conversion_factor = sqla.Column(sqla.Integer, nullable=False, default=1)
@@ -72,13 +72,13 @@ class EnergyConsumptionTimeseriesBySite(AuthMixin, Base):
 
 
 class EnergyConsumptionTimeseriesByBuilding(AuthMixin, Base):
-    __tablename__ = "energy_consumption_ts_by_building"
+    __tablename__ = "ener_cons_ts_by_building"
     __table_args__ = (sqla.UniqueConstraint("building_id", "source_id", "end_use_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     building_id = sqla.Column(sqla.ForeignKey("buildings.id"), nullable=False)
-    source_id = sqla.Column(sqla.ForeignKey("energy_sources.id"), nullable=False)
-    end_use_id = sqla.Column(sqla.ForeignKey("energy_end_uses.id"), nullable=False)
+    source_id = sqla.Column(sqla.ForeignKey("ener_sources.id"), nullable=False)
+    end_use_id = sqla.Column(sqla.ForeignKey("ener_end_uses.id"), nullable=False)
     timeseries_id = sqla.Column(sqla.ForeignKey("timeseries.id"), nullable=False)
     # Multiply TS values by kwh_conversion_factor to get Wh
     wh_conversion_factor = sqla.Column(sqla.Integer, nullable=False, default=1)
@@ -124,7 +124,7 @@ class EnergyConsumptionTimeseriesByBuilding(AuthMixin, Base):
 
 
 def init_db_energy():
-    """Create default energu sources and end uses
+    """Create default energy sources and end uses
 
     This function is meant to be used for tests or dev setups after create_all.
     Production setups should rely on migration scripts.

--- a/bemserver_core/model/sites.py
+++ b/bemserver_core/model/sites.py
@@ -8,7 +8,7 @@ from bemserver_core.common import PropertyType
 
 
 class StructuralElementProperty(AuthMixin, Base):
-    __tablename__ = "structural_element_properties"
+    __tablename__ = "struct_elem_props"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80), unique=True, nullable=False)
@@ -22,11 +22,11 @@ class StructuralElementProperty(AuthMixin, Base):
 
 
 class SiteProperty(AuthMixin, Base):
-    __tablename__ = "site_properties"
+    __tablename__ = "site_props"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("structural_element_properties.id"), unique=True, nullable=False
+        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -35,11 +35,11 @@ class SiteProperty(AuthMixin, Base):
 
 
 class BuildingProperty(AuthMixin, Base):
-    __tablename__ = "building_properties"
+    __tablename__ = "building_props"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("structural_element_properties.id"), unique=True, nullable=False
+        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -48,11 +48,11 @@ class BuildingProperty(AuthMixin, Base):
 
 
 class StoreyProperty(AuthMixin, Base):
-    __tablename__ = "storey_properties"
+    __tablename__ = "storey_props"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("structural_element_properties.id"), unique=True, nullable=False
+        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -61,11 +61,11 @@ class StoreyProperty(AuthMixin, Base):
 
 
 class SpaceProperty(AuthMixin, Base):
-    __tablename__ = "space_properties"
+    __tablename__ = "space_props"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("structural_element_properties.id"), unique=True, nullable=False
+        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -74,11 +74,11 @@ class SpaceProperty(AuthMixin, Base):
 
 
 class ZoneProperty(AuthMixin, Base):
-    __tablename__ = "zone_properties"
+    __tablename__ = "zone_props"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("structural_element_properties.id"), unique=True, nullable=False
+        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -299,9 +299,7 @@ class SitePropertyData(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     site_id = sqla.Column(sqla.ForeignKey("sites.id"), nullable=False)
-    site_property_id = sqla.Column(
-        sqla.ForeignKey("site_properties.id"), nullable=False
-    )
+    site_property_id = sqla.Column(sqla.ForeignKey("site_props.id"), nullable=False)
     value = sqla.Column(sqla.String(100), nullable=False)
 
     site = sqla.orm.relationship(
@@ -334,13 +332,13 @@ class SitePropertyData(AuthMixin, Base):
 
 
 class BuildingPropertyData(AuthMixin, Base):
-    __tablename__ = "building_property_data"
+    __tablename__ = "building_prop_data"
     __table_args__ = (sqla.UniqueConstraint("building_id", "building_property_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     building_id = sqla.Column(sqla.ForeignKey("buildings.id"), nullable=False)
     building_property_id = sqla.Column(
-        sqla.ForeignKey("building_properties.id"), nullable=False
+        sqla.ForeignKey("building_props.id"), nullable=False
     )
     value = sqla.Column(sqla.String(100), nullable=False)
 
@@ -378,14 +376,12 @@ class BuildingPropertyData(AuthMixin, Base):
 
 
 class StoreyPropertyData(AuthMixin, Base):
-    __tablename__ = "storey_property_data"
+    __tablename__ = "storey_prop_data"
     __table_args__ = (sqla.UniqueConstraint("storey_id", "storey_property_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     storey_id = sqla.Column(sqla.ForeignKey("storeys.id"), nullable=False)
-    storey_property_id = sqla.Column(
-        sqla.ForeignKey("storey_properties.id"), nullable=False
-    )
+    storey_property_id = sqla.Column(sqla.ForeignKey("storey_props.id"), nullable=False)
     value = sqla.Column(sqla.String(100), nullable=False)
 
     storey = sqla.orm.relationship(
@@ -418,14 +414,12 @@ class StoreyPropertyData(AuthMixin, Base):
 
 
 class SpacePropertyData(AuthMixin, Base):
-    __tablename__ = "space_property_data"
+    __tablename__ = "space_prop_data"
     __table_args__ = (sqla.UniqueConstraint("space_id", "space_property_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     space_id = sqla.Column(sqla.ForeignKey("spaces.id"), nullable=False)
-    space_property_id = sqla.Column(
-        sqla.ForeignKey("space_properties.id"), nullable=False
-    )
+    space_property_id = sqla.Column(sqla.ForeignKey("space_props.id"), nullable=False)
     value = sqla.Column(sqla.String(100), nullable=False)
 
     space = sqla.orm.relationship(
@@ -458,14 +452,12 @@ class SpacePropertyData(AuthMixin, Base):
 
 
 class ZonePropertyData(AuthMixin, Base):
-    __tablename__ = "zone_property_data"
+    __tablename__ = "zone_prop_data"
     __table_args__ = (sqla.UniqueConstraint("zone_id", "zone_property_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     zone_id = sqla.Column(sqla.ForeignKey("zones.id"), nullable=False)
-    zone_property_id = sqla.Column(
-        sqla.ForeignKey("zone_properties.id"), nullable=False
-    )
+    zone_property_id = sqla.Column(sqla.ForeignKey("zone_props.id"), nullable=False)
     value = sqla.Column(sqla.String(100), nullable=False)
 
     zone = sqla.orm.relationship(

--- a/bemserver_core/model/sites.py
+++ b/bemserver_core/model/sites.py
@@ -26,7 +26,10 @@ class SiteProperty(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
+        "struct_elem_prop_id",
+        sqla.ForeignKey("struct_elem_props.id"),
+        unique=True,
+        nullable=False,
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -39,7 +42,10 @@ class BuildingProperty(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
+        "struct_elem_prop_id",
+        sqla.ForeignKey("struct_elem_props.id"),
+        unique=True,
+        nullable=False,
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -52,7 +58,10 @@ class StoreyProperty(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
+        "struct_elem_prop_id",
+        sqla.ForeignKey("struct_elem_props.id"),
+        unique=True,
+        nullable=False,
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -65,7 +74,10 @@ class SpaceProperty(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
+        "struct_elem_prop_id",
+        sqla.ForeignKey("struct_elem_props.id"),
+        unique=True,
+        nullable=False,
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -78,7 +90,10 @@ class ZoneProperty(AuthMixin, Base):
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     structural_element_property_id = sqla.Column(
-        sqla.ForeignKey("struct_elem_props.id"), unique=True, nullable=False
+        "struct_elem_prop_id",
+        sqla.ForeignKey("struct_elem_props.id"),
+        unique=True,
+        nullable=False,
     )
     structural_element_property = sqla.orm.relationship(
         "StructuralElementProperty",
@@ -295,11 +310,13 @@ class Zone(AuthMixin, Base):
 
 class SitePropertyData(AuthMixin, Base):
     __tablename__ = "site_property_data"
-    __table_args__ = (sqla.UniqueConstraint("site_id", "site_property_id"),)
+    __table_args__ = (sqla.UniqueConstraint("site_id", "site_prop_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     site_id = sqla.Column(sqla.ForeignKey("sites.id"), nullable=False)
-    site_property_id = sqla.Column(sqla.ForeignKey("site_props.id"), nullable=False)
+    site_property_id = sqla.Column(
+        "site_prop_id", sqla.ForeignKey("site_props.id"), nullable=False
+    )
     value = sqla.Column(sqla.String(100), nullable=False)
 
     site = sqla.orm.relationship(
@@ -333,12 +350,12 @@ class SitePropertyData(AuthMixin, Base):
 
 class BuildingPropertyData(AuthMixin, Base):
     __tablename__ = "building_prop_data"
-    __table_args__ = (sqla.UniqueConstraint("building_id", "building_property_id"),)
+    __table_args__ = (sqla.UniqueConstraint("building_id", "building_prop_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     building_id = sqla.Column(sqla.ForeignKey("buildings.id"), nullable=False)
     building_property_id = sqla.Column(
-        sqla.ForeignKey("building_props.id"), nullable=False
+        "building_prop_id", sqla.ForeignKey("building_props.id"), nullable=False
     )
     value = sqla.Column(sqla.String(100), nullable=False)
 
@@ -377,11 +394,13 @@ class BuildingPropertyData(AuthMixin, Base):
 
 class StoreyPropertyData(AuthMixin, Base):
     __tablename__ = "storey_prop_data"
-    __table_args__ = (sqla.UniqueConstraint("storey_id", "storey_property_id"),)
+    __table_args__ = (sqla.UniqueConstraint("storey_id", "storey_prop_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     storey_id = sqla.Column(sqla.ForeignKey("storeys.id"), nullable=False)
-    storey_property_id = sqla.Column(sqla.ForeignKey("storey_props.id"), nullable=False)
+    storey_property_id = sqla.Column(
+        "storey_prop_id", sqla.ForeignKey("storey_props.id"), nullable=False
+    )
     value = sqla.Column(sqla.String(100), nullable=False)
 
     storey = sqla.orm.relationship(
@@ -415,11 +434,13 @@ class StoreyPropertyData(AuthMixin, Base):
 
 class SpacePropertyData(AuthMixin, Base):
     __tablename__ = "space_prop_data"
-    __table_args__ = (sqla.UniqueConstraint("space_id", "space_property_id"),)
+    __table_args__ = (sqla.UniqueConstraint("space_id", "space_prop_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     space_id = sqla.Column(sqla.ForeignKey("spaces.id"), nullable=False)
-    space_property_id = sqla.Column(sqla.ForeignKey("space_props.id"), nullable=False)
+    space_property_id = sqla.Column(
+        "space_prop_id", sqla.ForeignKey("space_props.id"), nullable=False
+    )
     value = sqla.Column(sqla.String(100), nullable=False)
 
     space = sqla.orm.relationship(
@@ -453,11 +474,13 @@ class SpacePropertyData(AuthMixin, Base):
 
 class ZonePropertyData(AuthMixin, Base):
     __tablename__ = "zone_prop_data"
-    __table_args__ = (sqla.UniqueConstraint("zone_id", "zone_property_id"),)
+    __table_args__ = (sqla.UniqueConstraint("zone_id", "zone_prop_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     zone_id = sqla.Column(sqla.ForeignKey("zones.id"), nullable=False)
-    zone_property_id = sqla.Column(sqla.ForeignKey("zone_props.id"), nullable=False)
+    zone_property_id = sqla.Column(
+        "zone_prop_id", sqla.ForeignKey("zone_props.id"), nullable=False
+    )
     value = sqla.Column(sqla.String(100), nullable=False)
 
     zone = sqla.orm.relationship(

--- a/bemserver_core/model/timeseries.py
+++ b/bemserver_core/model/timeseries.py
@@ -15,7 +15,7 @@ from bemserver_core.exceptions import TimeseriesNotFoundError
 
 
 class TimeseriesProperty(AuthMixin, Base):
-    __tablename__ = "timeseries_properties"
+    __tablename__ = "ts_props"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80), unique=True, nullable=False)
@@ -29,7 +29,7 @@ class TimeseriesProperty(AuthMixin, Base):
 
 
 class TimeseriesDataState(AuthMixin, Base):
-    __tablename__ = "timeseries_data_states"
+    __tablename__ = "ts_data_states"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80), unique=True, nullable=False)
@@ -44,9 +44,7 @@ class Timeseries(AuthMixin, Base):
     description = sqla.Column(sqla.String(500))
     unit_symbol = sqla.Column(sqla.String(20))
     campaign_id = sqla.Column(sqla.ForeignKey("campaigns.id"), nullable=False)
-    campaign_scope_id = sqla.Column(
-        sqla.ForeignKey("campaign_scopes.id"), nullable=False
-    )
+    campaign_scope_id = sqla.Column(sqla.ForeignKey("c_scopes.id"), nullable=False)
 
     campaign = sqla.orm.relationship(
         "Campaign", backref=sqla.orm.backref("timeseries", cascade="all, delete-orphan")
@@ -283,14 +281,12 @@ class Timeseries(AuthMixin, Base):
 class TimeseriesPropertyData(AuthMixin, Base):
     """Timeseries property data"""
 
-    __tablename__ = "timeseries_property_data"
+    __tablename__ = "ts_prop_data"
     __table_args__ = (sqla.UniqueConstraint("timeseries_id", "property_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     timeseries_id = sqla.Column(sqla.ForeignKey("timeseries.id"), nullable=False)
-    property_id = sqla.Column(
-        sqla.ForeignKey("timeseries_properties.id"), nullable=False
-    )
+    property_id = sqla.Column(sqla.ForeignKey("ts_props.id"), nullable=False)
     value = sqla.Column(sqla.String(100), nullable=False)
 
     timeseries = sqla.orm.relationship(
@@ -321,14 +317,12 @@ class TimeseriesPropertyData(AuthMixin, Base):
 
 
 class TimeseriesByDataState(AuthMixin, Base):
-    __tablename__ = "timeseries_by_data_states"
+    __tablename__ = "ts_by_data_states"
     __table_args__ = (sqla.UniqueConstraint("timeseries_id", "data_state_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     timeseries_id = sqla.Column(sqla.ForeignKey("timeseries.id"), nullable=False)
-    data_state_id = sqla.Column(
-        sqla.ForeignKey("timeseries_data_states.id"), nullable=False
-    )
+    data_state_id = sqla.Column(sqla.ForeignKey("ts_data_states.id"), nullable=False)
 
     timeseries = sqla.orm.relationship(
         "Timeseries",
@@ -359,7 +353,7 @@ class TimeseriesByDataState(AuthMixin, Base):
 
 
 class TimeseriesBySite(AuthMixin, Base):
-    __tablename__ = "timeseries_by_sites"
+    __tablename__ = "ts_by_sites"
     __table_args__ = (sqla.UniqueConstraint("site_id", "timeseries_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
@@ -397,7 +391,7 @@ class TimeseriesBySite(AuthMixin, Base):
 
 
 class TimeseriesByBuilding(AuthMixin, Base):
-    __tablename__ = "timeseries_by_buildings"
+    __tablename__ = "ts_by_buildings"
     __table_args__ = (sqla.UniqueConstraint("building_id", "timeseries_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
@@ -439,7 +433,7 @@ class TimeseriesByBuilding(AuthMixin, Base):
 
 
 class TimeseriesByStorey(AuthMixin, Base):
-    __tablename__ = "timeseries_by_storeys"
+    __tablename__ = "ts_by_storeys"
     __table_args__ = (sqla.UniqueConstraint("storey_id", "timeseries_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
@@ -477,7 +471,7 @@ class TimeseriesByStorey(AuthMixin, Base):
 
 
 class TimeseriesBySpace(AuthMixin, Base):
-    __tablename__ = "timeseries_by_spaces"
+    __tablename__ = "ts_by_spaces"
     __table_args__ = (sqla.UniqueConstraint("space_id", "timeseries_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)

--- a/bemserver_core/model/timeseries_data.py
+++ b/bemserver_core/model/timeseries_data.py
@@ -6,12 +6,11 @@ from bemserver_core.database import Base, db
 
 class TimeseriesData(Base):
     __tablename__ = "ts_data"
-    __table_args__ = (
-        sqla.PrimaryKeyConstraint("timeseries_by_data_state_id", "timestamp"),
-    )
+    __table_args__ = (sqla.PrimaryKeyConstraint("ts_by_data_state_id", "timestamp"),)
 
     timestamp = sqla.Column(sqla.DateTime(timezone=True))
     timeseries_by_data_state_id = sqla.Column(
+        "ts_by_data_state_id",
         sqla.Integer,
         sqla.ForeignKey("ts_by_data_states.id"),
         nullable=False,

--- a/bemserver_core/model/timeseries_data.py
+++ b/bemserver_core/model/timeseries_data.py
@@ -5,7 +5,7 @@ from bemserver_core.database import Base, db
 
 
 class TimeseriesData(Base):
-    __tablename__ = "timeseries_data"
+    __tablename__ = "ts_data"
     __table_args__ = (
         sqla.PrimaryKeyConstraint("timeseries_by_data_state_id", "timestamp"),
     )
@@ -13,7 +13,7 @@ class TimeseriesData(Base):
     timestamp = sqla.Column(sqla.DateTime(timezone=True))
     timeseries_by_data_state_id = sqla.Column(
         sqla.Integer,
-        sqla.ForeignKey("timeseries_by_data_states.id"),
+        sqla.ForeignKey("ts_by_data_states.id"),
         nullable=False,
     )
     value = sqla.Column(sqla.Float)

--- a/bemserver_core/model/users.py
+++ b/bemserver_core/model/users.py
@@ -68,7 +68,7 @@ class User(AuthMixin, Base):
 
 
 class UserGroup(AuthMixin, Base):
-    __tablename__ = "user_groups"
+    __tablename__ = "u_groups"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80), unique=True, nullable=False)
@@ -97,12 +97,12 @@ class UserGroup(AuthMixin, Base):
 class UserByUserGroup(AuthMixin, Base):
     """UserGroup x User associations"""
 
-    __tablename__ = "users_by_user_groups"
+    __tablename__ = "users_by_u_groups"
     __table_args__ = (sqla.UniqueConstraint("user_id", "user_group_id"),)
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     user_id = sqla.Column(sqla.ForeignKey("users.id"), nullable=False)
-    user_group_id = sqla.Column(sqla.ForeignKey("user_groups.id"), nullable=False)
+    user_group_id = sqla.Column(sqla.ForeignKey("u_groups.id"), nullable=False)
 
     user = sqla.orm.relationship(
         User,

--- a/bemserver_core/scheduled_tasks/cleanup.py
+++ b/bemserver_core/scheduled_tasks/cleanup.py
@@ -97,7 +97,7 @@ class ST_CleanupByCampaign(AuthMixin, Base):
 
 
 class ST_CleanupByTimeseries(AuthMixin, Base):
-    __tablename__ = "st_cleanups_by_timeseries"
+    __tablename__ = "st_cleanups_by_ts"
 
     id = sqla.Column(sqla.Integer, primary_key=True)
     timeseries_id = sqla.Column(

--- a/tests/model/test_sites.py
+++ b/tests/model/test_sites.py
@@ -158,7 +158,7 @@ class TestSitePropertyModel:
             db.session.add(site_p_1)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -206,7 +206,7 @@ class TestSitePropertyModel:
             db.session.add(sp)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
 
@@ -232,7 +232,7 @@ class TestBuildingPropertyModel:
             db.session.add(building_p_1)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -280,7 +280,7 @@ class TestBuildingPropertyModel:
             db.session.add(bp)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
 
@@ -306,7 +306,7 @@ class TestStoreyPropertyModel:
             db.session.add(storey_p_1)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -354,7 +354,7 @@ class TestStoreyPropertyModel:
             db.session.add(sp)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
 
@@ -380,7 +380,7 @@ class TestSpacePropertyModel:
             db.session.add(space_p_1)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -428,7 +428,7 @@ class TestSpacePropertyModel:
             db.session.add(sp)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
 
@@ -454,7 +454,7 @@ class TestZonePropertyModel:
             db.session.add(zone_p_1)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -502,7 +502,7 @@ class TestZonePropertyModel:
             db.session.add(zp)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="structural_element_property_id cannot be modified",
+                match="struct_elem_prop_id cannot be modified",
             ):
                 db.session.commit()
 
@@ -1184,7 +1184,7 @@ class TestSitePropertyDataModel:
             db.session.add(spd)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="site_property_id cannot be modified",
+                match="site_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -1393,7 +1393,7 @@ class TestBuildingPropertyDataModel:
             db.session.add(bpd)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="building_property_id cannot be modified",
+                match="building_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -1600,7 +1600,7 @@ class TestStoreyPropertyDataModel:
             db.session.add(spd)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="storey_property_id cannot be modified",
+                match="storey_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -1805,7 +1805,7 @@ class TestSpacePropertyDataModel:
             db.session.add(spd)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="space_property_id cannot be modified",
+                match="space_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()
@@ -2008,7 +2008,7 @@ class TestZonePropertyDataModel:
             db.session.add(zpd)
             with pytest.raises(
                 sqla.exc.IntegrityError,
-                match="zone_property_id cannot be modified",
+                match="zone_prop_id cannot be modified",
             ):
                 db.session.commit()
             db.session.rollback()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ def create_timeseries_data(timeseries, data_state, timestamps, values):
         )
         in_df = in_df.melt(
             value_vars=in_df.columns,
-            var_name="timeseries_by_data_state_id",
+            var_name="ts_by_data_state_id",
             ignore_index=False,
         )
         data_rows = [


### PR DESCRIPTION
We use a naming convention to ensure names are deterministic in DB, not only for readability but also to make dropping stuff possible in migrations.

However, due to the 63 chars limitation in PostgreSQL, names are truncated and a random number is appended, which defeats the point of the convention.

```py
NAMING_CONVENTION = {
    "ix": "ix_%(column_0_label)s",
    "uq": "uq_%(table_name)s_%(column_0_name)s",
    "ck": "ck_%(table_name)s_%(constraint_name)s",
    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
    "pk": "pk_%(table_name)s",
}
```

This PR shortens table and column names to avoid truncations.

