### PR TITLE
Use pivot, not pivot_table, in get_timeseries_buckets_data

### DIFF
--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -342,14 +342,8 @@ class TimeseriesDataIO:
             .tz_localize(None).tz_localize(timezone)
         )
 
-        data_df = pd.pivot_table(
-            data_df,
-            index="timestamp",
-            columns=col_label,
-            values="value",
-            aggfunc="sum",
-            fill_value=fill_value,
-        )
+        # Pivot table to get timeseries in columns
+        data_df = data_df.pivot(values="value", columns=col_label).fillna(fill_value)
 
         # Variable size intervals are aggregated to 1 x unit due to date_trunc
         # Further aggregation is achieved here in pandas

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -426,6 +426,40 @@ class TestTimeseriesDataIO:
         timestamps = pd.date_range(
             start=start_dt, end=end_dt, inclusive="left", freq="H"
         )
+
+        ts_l = (ts_0, ts_2, ts_4)
+
+        with CurrentUser(admin_user):
+
+            # No data
+            data_df = tsdio.get_timeseries_buckets_data(
+                start_dt,
+                end_dt,
+                ts_l,
+                ds_1,
+                1,
+                "day",
+            )
+
+            index = pd.DatetimeIndex(
+                [
+                    "2020-01-01T00:00:00",
+                    "2020-01-02T00:00:00",
+                    "2020-01-03T00:00:00",
+                ],
+                name="timestamp",
+                tz="UTC",
+            )
+            expected_data_df = pd.DataFrame(
+                {
+                    ts_0.id: [np.nan, np.nan, np.nan],
+                    ts_2.id: [np.nan, np.nan, np.nan],
+                    ts_4.id: [np.nan, np.nan, np.nan],
+                },
+                index=index,
+            )
+            assert data_df.equals(expected_data_df)
+
         values_1 = range(24 * 3)
         create_timeseries_data(ts_0, ds_1, timestamps, values_1)
         values_2 = [10 + 2 * i for i in range(24 * 2)]


### PR DESCRIPTION
No need to aggregate here, uniqueness is guaranteed.

This removes a pandas deprecation warning.

Also test the "no data" case at least once.