### PR TITLE
Rework get_timeseries_buckets_data: use date_trunc for all aggregations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,17 +6,9 @@ BEMServer core
 Installation
 ============
 
-Install PostgreSQL and TimescaleDB.
+Install PostgreSQL::
 
-https://docs.timescale.com/latest/getting-started/setup
-
-Create a database and install TimescaleDB extension (should be done after each
-TimescaleDB update).
-
-Assuming the user has database creation permission:::
-
-$ createdb bemserver
-$ psql -U $USER -d bemserver -c "CREATE EXTENSION IF NOT EXISTS timescaledb"
+$ aptitude install postgresql
 
 Install prerequisites for psycopg2 compilation (assuming Debian system)::
 
@@ -29,6 +21,12 @@ $ pip install bemserver_core
 
 Database setup
 ==============
+
+Create a database.
+
+Assuming the user has database creation permission::
+
+$ createdb bemserver
 
 Set DB URI in an evironment variable::
 
@@ -59,3 +57,27 @@ User creation
 Create an admin user::
 
 $ bemserver_create_user --name chuck --email chuck@norris.com --admin
+
+Other users may be created later from the web GUI using this one.
+
+
+Using TimescaleDB
+=================
+
+TimescaleDB is a PostgreSQL extension specialized in timeseries data. It may be
+used to improve the performance of read-write operations in the table storing
+timeseries data.
+
+Installation instructions are detailed in the documentation:
+
+https://docs.timescale.com/latest/getting-started/setup
+
+Install TimescaleDB as described there, then setup the extension in the database
+(this should be done after each TimescaleDB update)::
+
+$ psql -U $USER -d bemserver -c "CREATE EXTENSION IF NOT EXISTS timescaledb"
+
+After the tables are created by the first migration or the `setup_db` command,
+create hypertables in timeseries data table::
+
+$ psql -U $USER -d bemserver -c "SELECT create_hypertable('ts_data', 'timestamp')"

--- a/bemserver_core/commands.py
+++ b/bemserver_core/commands.py
@@ -29,7 +29,6 @@ def setup_db():
     model.campaigns.init_db_campaigns_triggers()
     model.timeseries.init_db_timeseries_triggers()
     model.timeseries.init_db_timeseries()
-    model.timeseries_data.init_db_timeseries_data()
     model.sites.init_db_structural_elements_triggers()
     model.energy.init_db_energy()
 

--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -198,7 +198,9 @@ class TimeseriesDataIO:
             data, columns=("timestamp", "id", "name", "value")
         ).set_index("timestamp")
         data_df["value"] = data_df["value"].astype(float)
-        data_df.index = pd.DatetimeIndex(data_df.index, tz="UTC").tz_convert(timezone)
+        data_df.index = pd.DatetimeIndex(data_df.index, tz="UTC").tz_convert(
+            ZoneInfo(timezone)
+        )
 
         data_df = data_df.pivot(columns=col_label, values="value")
 
@@ -302,7 +304,7 @@ class TimeseriesDataIO:
             data, columns=("timestamp", "id", "name", "value")
         ).set_index("timestamp")
 
-        data_df.index = pd.DatetimeIndex(data_df.index).tz_localize(timezone)
+        data_df.index = pd.DatetimeIndex(data_df.index).tz_localize(ZoneInfo(timezone))
 
         # Pivot table to get timeseries in columns
         data_df = data_df.pivot(values="value", columns=col_label).fillna(fill_value)

--- a/bemserver_core/model/timeseries_data.py
+++ b/bemserver_core/model/timeseries_data.py
@@ -1,7 +1,7 @@
 """Timeseries data"""
 import sqlalchemy as sqla
 
-from bemserver_core.database import Base, db
+from bemserver_core.database import Base
 
 
 class TimeseriesData(Base):
@@ -21,21 +21,3 @@ class TimeseriesData(Base):
         "TimeseriesByDataState",
         backref=sqla.orm.backref("timeseries_data", cascade="all, delete-orphan"),
     )
-
-
-def init_db_timeseries_data():
-    """Create timescale hypertable
-
-    This function is meant to be used for tests or dev setups after create_all.
-    Production setups should rely on migration scripts.
-    """
-    db.session.execute(
-        sqla.DDL(
-            "SELECT create_hypertable("
-            f"  '{TimeseriesData.__table__}',"
-            "  'timestamp',"
-            "  create_default_indexes => False"
-            ");"
-        )
-    )
-    db.session.commit()

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -380,7 +380,7 @@ class TestTimeseriesDataIO:
                     "2020-01-01T02:00:00+00:00",
                 ],
                 name="timestamp",
-                tz="Europe/Paris",
+                tz=ZoneInfo("Europe/Paris"),
             )
             assert data_df.equals(expected_data_df)
 

--- a/tests/process/test_completeness.py
+++ b/tests/process/test_completeness.py
@@ -14,179 +14,10 @@ from bemserver_core.model import (
 )
 from bemserver_core.authorization import CurrentUser, OpenBar
 
-from bemserver_core.process.completeness import (
-    compute_completeness,
-    gen_seconds_per_bucket,
-)
+from bemserver_core.process.completeness import compute_completeness
 
 
 class TestCompleteness:
-    def test_gen_seconds_per_bucket(self):
-        # Bucket width 1 second
-        start_dt = dt.datetime(2020, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
-        end_dt = dt.datetime(2020, 1, 1, 0, 0, 3, tzinfo=dt.timezone.utc)
-        ret = gen_seconds_per_bucket(
-            start_dt,
-            end_dt,
-            1,
-            "second",
-            "UTC",
-        )
-        expected = pd.Series(
-            3 * [1],
-            index=pd.date_range(
-                start_dt, end_dt, inclusive="left", freq="S", name="timestamp"
-            ),
-        )
-        assert ret.equals(expected)
-        assert ret.index[0] == start_dt
-
-        # Bucket width 1 minute, TZ different from start_dt
-        start_dt = dt.datetime(2020, 1, 1, 0, 0, tzinfo=dt.timezone.utc)
-        end_dt = dt.datetime(2020, 1, 1, 0, 3, tzinfo=dt.timezone.utc)
-        start_bucket_dt = start_dt.astimezone(ZoneInfo("Europe/Paris"))
-        end_bucket_dt = end_dt.astimezone(ZoneInfo("Europe/Paris"))
-        ret = gen_seconds_per_bucket(
-            start_dt,
-            end_dt,
-            1,
-            "minute",
-            "Europe/Paris",
-        )
-        expected = pd.Series(
-            3 * [60],
-            index=pd.date_range(
-                start_bucket_dt.replace(tzinfo=None),
-                end_bucket_dt.replace(tzinfo=None),
-                inclusive="left",
-                freq="T",
-                name="timestamp",
-                tz="Europe/Paris",
-            ),
-        )
-        assert ret.equals(expected)
-        assert ret.index[0] == start_bucket_dt
-
-        # Bucket width 1 hour, uneven start time
-        start_dt = dt.datetime(2020, 1, 1, 0, 12, 43, tzinfo=dt.timezone.utc)
-        end_dt = dt.datetime(2020, 1, 1, 3, 12, 43, tzinfo=dt.timezone.utc)
-        ret = gen_seconds_per_bucket(
-            start_dt,
-            end_dt,
-            1,
-            "hour",
-            "UTC",
-        )
-        expected = pd.Series(
-            3 * [3600],
-            index=pd.date_range(
-                start_dt, end_dt, inclusive="left", freq="H", name="timestamp"
-            ),
-        )
-        assert ret.equals(expected)
-        assert ret.index[0] == start_dt
-
-        # Bucket width 1 day, TZ not UTC
-        start_dt = dt.datetime(2020, 1, 1, 6, 0, tzinfo=dt.timezone.utc)
-        end_dt = dt.datetime(2020, 1, 3, tzinfo=dt.timezone.utc)
-        start_bucket_dt = start_dt.astimezone(ZoneInfo("Europe/Paris"))
-        end_bucket_dt = end_dt.astimezone(ZoneInfo("Europe/Paris"))
-        ret = gen_seconds_per_bucket(
-            start_dt,
-            end_dt,
-            1,
-            "day",
-            "Europe/Paris",
-        )
-        expected = pd.Series(
-            [3600 * 24, 3600 * 18],
-            index=pd.date_range(
-                start_bucket_dt.replace(tzinfo=None),
-                end_bucket_dt.replace(tzinfo=None),
-                inclusive="left",
-                freq="D",
-                name="timestamp",
-                tz="Europe/Paris",
-            ),
-        )
-        assert ret.equals(expected)
-        assert ret.index[0] == start_bucket_dt
-
-        # Bucket width 1 week
-        start_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
-        end_dt = dt.datetime(2020, 1, 22, tzinfo=dt.timezone.utc)
-        start_bucket_dt = dt.datetime(2019, 12, 30, tzinfo=dt.timezone.utc)
-        end_bucket_dt = dt.datetime(2020, 1, 22, tzinfo=dt.timezone.utc)
-        ret = gen_seconds_per_bucket(
-            start_dt,
-            end_dt,
-            1,
-            "week",
-            "UTC",
-        )
-        expected = pd.Series(
-            [3600 * 24 * 5] + 2 * [3600 * 24 * 7] + [3600 * 24 * 2],
-            index=pd.date_range(
-                start_bucket_dt,
-                end_bucket_dt,
-                inclusive="left",
-                freq="W-MON",
-                name="timestamp",
-            ),
-        )
-        assert ret.equals(expected)
-        assert ret.index[0] == start_bucket_dt
-
-        # Bucket width 1 month
-        start_dt = dt.datetime(2020, 1, 30, tzinfo=dt.timezone.utc)
-        end_dt = dt.datetime(2020, 3, 3, tzinfo=dt.timezone.utc)
-        start_bucket_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
-        end_bucket_dt = dt.datetime(2020, 4, 1, tzinfo=dt.timezone.utc)
-        ret = gen_seconds_per_bucket(
-            start_dt,
-            end_dt,
-            1,
-            "month",
-            "UTC",
-        )
-        expected = pd.Series(
-            [3600 * 24 * 2] + [3600 * 24 * 29] + [3600 * 24 * 2],
-            index=pd.date_range(
-                start_bucket_dt,
-                end_bucket_dt,
-                inclusive="left",
-                freq="MS",
-                name="timestamp",
-            ),
-        )
-        assert ret.equals(expected)
-        assert ret.index[0] == start_bucket_dt
-
-        # Bucket width 1 year
-        start_dt = dt.datetime(2020, 12, 1, tzinfo=dt.timezone.utc)
-        end_dt = dt.datetime(2021, 2, 1, tzinfo=dt.timezone.utc)
-        start_bucket_dt = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
-        end_bucket_dt = dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc)
-        ret = gen_seconds_per_bucket(
-            start_dt,
-            end_dt,
-            1,
-            "year",
-            "UTC",
-        )
-        expected = pd.Series(
-            [3600 * 24 * 31] + [3600 * 24 * 31],
-            index=pd.date_range(
-                start_bucket_dt,
-                end_bucket_dt,
-                inclusive="left",
-                freq="AS",
-                name="timestamp",
-            ),
-        )
-        assert ret.equals(expected)
-        assert ret.index[0] == start_bucket_dt
-
     @pytest.mark.usefixtures("timeseries_property_data")
     @pytest.mark.parametrize("timeseries", (5,), indirect=True)
     def test_compute_completeness(self, users, timeseries):
@@ -406,7 +237,7 @@ class TestCompleteness:
             ]
 
             # 2 days - daily step - TZ offset - start_dt not at midnight
-            # Non-reg ression test for an issue with date range generation
+            # Just checking date range generation
             ret = compute_completeness(
                 start_dt_plus_8_hours,
                 start_dt_plus_2_days,
@@ -417,8 +248,9 @@ class TestCompleteness:
                 timezone="Europe/Paris",
             )
             assert ret["timestamps"] == [
-                start_dt_plus_8_hours,
-                start_dt_plus_8_hours + dt.timedelta(days=1),
+                dt.datetime(2020, 1, 1, tzinfo=ZoneInfo("Europe/Paris")),
+                dt.datetime(2020, 1, 2, tzinfo=ZoneInfo("Europe/Paris")),
+                dt.datetime(2020, 1, 3, tzinfo=ZoneInfo("Europe/Paris")),
             ]
 
             # 1 day - minute step
@@ -451,6 +283,8 @@ class TestCompleteness:
             assert ret["timeseries"][5]["expected_count"] == 24 * 60 * [None]
 
             # 2 hours - hour step with offset
+            # Aggregation interval start time is floored to round to interval
+            # so we get the same intervals but less data in the first interval
             ret = compute_completeness(
                 start_dt + dt.timedelta(minutes=30),
                 start_dt + dt.timedelta(hours=3),
@@ -461,58 +295,58 @@ class TestCompleteness:
             )
             assert ret == {
                 "timestamps": [
-                    dt.datetime(2020, 1, 1, 0, 30, tzinfo=dt.timezone.utc),
-                    dt.datetime(2020, 1, 1, 1, 30, tzinfo=dt.timezone.utc),
-                    dt.datetime(2020, 1, 1, 2, 30, tzinfo=dt.timezone.utc),
+                    dt.datetime(2020, 1, 1, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2020, 1, 1, 1, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2020, 1, 1, 2, 0, tzinfo=dt.timezone.utc),
                 ],
                 "timeseries": {
                     1: {
                         "name": "Timeseries 1",
-                        "count": [6, 6, 3],
+                        "count": [3, 6, 6],
                         "ratio": [1.0, 1.0, 1.0],
                         "total_count": 15,
                         "avg_count": 5.0,
                         "avg_ratio": 1.0,
                         "interval": 600.0,
                         "undefined_interval": False,
-                        "expected_count": [6.0, 6.0, 3.0],
+                        "expected_count": [3.0, 6.0, 6.0],
                     },
                     2: {
                         "name": "Timeseries 2",
-                        "count": [6, 6, 3],
+                        "count": [3, 6, 6],
                         "ratio": [1.0, 1.0, 1.0],
                         "total_count": 15,
                         "avg_count": 5.0,
                         "avg_ratio": 1.0,
                         "interval": 600.0,
                         "undefined_interval": False,
-                        "expected_count": [6.0, 6.0, 3.0],
+                        "expected_count": [3.0, 6.0, 6.0],
                     },
                     3: {
                         "name": "Timeseries 3",
-                        "count": [8, 8, 5],
+                        "count": [4, 8, 9],
                         "ratio": [
                             2.6666666666666665,
                             2.6666666666666665,
-                            3.3333333333333335,
+                            3.0,
                         ],
                         "total_count": 21,
                         "avg_count": 7.0,
-                        "avg_ratio": 2.888888888888889,
+                        "avg_ratio": 2.7777777777777772,
                         "interval": 1200.0,
                         "undefined_interval": False,
-                        "expected_count": [3.0, 3.0, 1.5],
+                        "expected_count": [1.5, 3.0, 3.0],
                     },
                     4: {
                         "name": "Timeseries 4",
-                        "count": [6, 6, 3],
+                        "count": [3, 6, 6],
                         "ratio": [1.0, 1.0, 1.0],
                         "total_count": 15,
                         "avg_count": 5.0,
                         "avg_ratio": 1.0,
                         "interval": 600.0,
                         "undefined_interval": True,
-                        "expected_count": [6.0, 6.0, 3.0],
+                        "expected_count": [3.0, 6.0, 6.0],
                     },
                     5: {
                         "name": "Timeseries 5",


### PR DESCRIPTION
Current implementation has issues with DST changes. 

It is broken by design because the query returns naive datetimes in local time, which is wrong on ambiguous dates (i.e. fall DST change dates). This will crash with pytz timezones or return a wrong result if we change to Python's `ZoneInfo` timezones.

We investigated and it seems the only way around this is to rely on the `timezone` option of PostgreSQL's `date_trunc`.

A downside is that we can't manage offsets anymore: buckets are aligned to their "natural" boundaries.

Also, when aggregating to a multiple, like 2 hours, the aggregation is done in the SQL first to the aggregation level (hour) then finished in Python code to aggregate buckets together (2). This was the case for variable bucket widths and this PR generalizes this for all levels. This is wrong for intervals of variable size (you can't average buckets of different sizes together) and the only sane way to deal with this would be to forbid multiples, at least for variable size intervals. We'll deal with this later.

Those issues can be avoided by querying only on rounded bounds and without multiple, so the situation is overall better than current situation where some legit queries are screwed with no workaround.

OTOH, this PR simplifies the code, which is great, and it fixes a few minor issues along the way. Also, it removes the only use of TimescaleDB features, so that the only benefit of using it is the expected performance improvement. This PR therefore makes it optional, leaving the decision to the user.
