### PR TITLE
Fix deprecation error in completeness process

### DIFF
--- a/bemserver_core/process/completeness.py
+++ b/bemserver_core/process/completeness.py
@@ -69,13 +69,22 @@ def compute_completeness(
         for i, col in zip(intervals, counts_df.columns)
     ]
 
+    # Add a special case for empty intervals to avoid a deprecation warning
+    # in div() and mul(). See https://stackoverflow.com/questions/74448601/
+
     # Compute expected count (nb seconds per bucket / interval)
-    expected_counts_df = pd.DataFrame(
-        {col: nb_s_per_bucket for col in counts_df.columns}, index=counts_df.index
-    ).div(intervals, axis=1)
+    if not intervals:
+        expected_counts_df = pd.DataFrame({}, index=counts_df.index)
+    else:
+        expected_counts_df = pd.DataFrame(
+            {col: nb_s_per_bucket for col in counts_df.columns}, index=counts_df.index
+        ).div(intervals, axis=1)
 
     # Compute ratios (data rate x interval)
-    ratios_df = rates_df.mul(intervals, axis=1)
+    if not intervals:
+        ratios_df = pd.DataFrame({}, index=counts_df.index)
+    else:
+        ratios_df = rates_df.mul(intervals, axis=1)
     avg_ratios_df = ratios_df.mean()
 
     # Replace NaN with None


### PR DESCRIPTION
Current code produces a warning when the list of timeseries is empty.

I couldn't find a better solution than adding a special case. It is more verbose but it shouldn't be less efficient anyway.

We can rework this someday if we find a better way. See https://stackoverflow.com/questions/74448601/multiply-divide-dataframe-columns-by-list-series-along-axis-1.

