### PR TITLE
Rework and document Celery deployment

### DIFF
--- a/docs/deployment/README.rst
+++ b/docs/deployment/README.rst
@@ -1,0 +1,11 @@
+Deployment documentation
+========================
+
+Create bemserver user and required directories.
+
+    $ adduser --system --home /var/run/bemserver --group bemserver
+
+    $ mkdir -m 0750 /var/log/bemserver
+    $ chown bemserver:bemserver /var/log/bemserver
+
+Copy etc directory's content into /etc and edit config files.

--- a/docs/deployment/etc/logrotate.d/bemserver
+++ b/docs/deployment/etc/logrotate.d/bemserver
@@ -1,0 +1,6 @@
+/var/log/bemserver/*.log {
+    weekly
+    rotate 10
+    compress
+    delaycompress
+}

--- a/docs/deployment/etc/systemd/system/bemserver-celery-beat.service
+++ b/docs/deployment/etc/systemd/system/bemserver-celery-beat.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=BEMServer Celery beat scheduler
+Requires=postgresql.service redis-server.service
+After=postgresql.service redis-server.service
+
+[Service]
+Type=simple
+User=bemserver
+Group=bemserver
+ExecStart=/bin/sh -c '${CELERY_BIN} -A bemserver_core beat \
+  --schedule=/var/run/bemserver/%n-schedule \
+  --pidfile=/var/run/bemserver/%n.pid \
+  --logfile=/var/log/bemserver/%n.log \
+  --loglevel=${CELERYBEAT_LOG_LEVEL}'
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/deployment/etc/systemd/system/bemserver-celery-beat.service.d/bemserver-celery-beat.conf
+++ b/docs/deployment/etc/systemd/system/bemserver-celery-beat.service.d/bemserver-celery-beat.conf
@@ -1,0 +1,5 @@
+[Service]
+
+Environment="BEMSERVER_CELERY_SETTINGS_FILE=/srv/bemserver-core/bemserver-celery-settings.py"
+Environment="CELERY_BIN=/srv/bemserver-core/venv_bemserver_core/bin/celery"
+Environment="CELERYBEAT_LOG_LEVEL=WARNING"

--- a/docs/deployment/etc/systemd/system/bemserver-celery.service
+++ b/docs/deployment/etc/systemd/system/bemserver-celery.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=BEMServer Celery worker
+Requires=postgresql.service redis-server.service
+After=postgresql.service redis-server.service
+
+[Service]
+Type=forking
+User=bemserver
+Group=bemserver
+
+ExecStart=/bin/sh -c '${CELERY_BIN} -A bemserver_core multi start ${CELERYD_NODES} \
+  --pidfile=/var/run/bemserver/%n.pid \
+  --logfile=/var/log/bemserver/%n%%I.log \
+  --loglevel=${CELERYD_LOG_LEVEL} \
+  --queues=${CELERYD_QUEUES}'
+ExecStop=/bin/sh -c '${CELERY_BIN} multi stopwait ${CELERYD_NODES} \
+  --pidfile=/var/run/bemserver/%n.pid \
+  --logfile=/var/log/bemserver/%n%%I.log \
+  --loglevel=${CELERYD_LOG_LEVEL}'
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/deployment/etc/systemd/system/bemserver-celery.service.d/bemserver-celery.conf
+++ b/docs/deployment/etc/systemd/system/bemserver-celery.service.d/bemserver-celery.conf
@@ -1,0 +1,7 @@
+[Service]
+
+Environment="BEMSERVER_CELERY_SETTINGS_FILE=/srv/bemserver-core/bemserver-celery-settings.py"
+Environment="CELERY_BIN=/srv/bemserver-core/venv_bemserver_core/bin/celery"
+Environment="CELERYD_NODES=w1 w2"
+Environment="CELERYD_QUEUES='bemserver_core'"
+Environment="CELERYD_LOG_LEVEL=WARNING"

--- a/docs/deployment/etc/tmpfiles.d/bemserver.conf
+++ b/docs/deployment/etc/tmpfiles.d/bemserver.conf
@@ -1,0 +1,1 @@
+d /var/run/bemserver 0750 bemserver bemserver -


### PR DESCRIPTION
- Get DB_URL from config file, not env var. Since we have a config file, we might as well use it for the DB URL rather than requiring another env var. Passing it as env var dates back to before the config file was added.

- Add deployment sample files