### PR TITLE
Make Timeseries.unit_symbol default to ""

### DIFF
--- a/bemserver_core/model/timeseries.py
+++ b/bemserver_core/model/timeseries.py
@@ -43,7 +43,7 @@ class Timeseries(AuthMixin, Base):
     id = sqla.Column(sqla.Integer, primary_key=True)
     name = sqla.Column(sqla.String(80), nullable=False)
     description = sqla.Column(sqla.String(500))
-    unit_symbol = sqla.Column(sqla.String(20))
+    unit_symbol = sqla.Column(sqla.String(20), default="", nullable=False)
     campaign_id = sqla.Column(sqla.ForeignKey("campaigns.id"), nullable=False)
     campaign_scope_id = sqla.Column(sqla.ForeignKey("c_scopes.id"), nullable=False)
 

--- a/tests/process/test_energy_consumption.py
+++ b/tests/process/test_energy_consumption.py
@@ -167,7 +167,7 @@ class TestEnergyConsumption:
             assert ret["energy"]["all"]["all"] == [142.0]
 
             # Check wrong unit
-            timeseries[0].unit_symbol = None
+            timeseries[0].unit_symbol = ""
             with pytest.raises(BEMServerCoreDimensionalityError):
                 ret = compute_energy_consumption_breakdown_for_site(
                     site_1, start_dt, end_dt, 1, "hour"
@@ -261,7 +261,7 @@ class TestEnergyConsumption:
             assert ret["energy"]["all"]["all"] == [142.0]
 
             # Check wrong unit
-            timeseries[0].unit_symbol = None
+            timeseries[0].unit_symbol = ""
             with pytest.raises(BEMServerCoreDimensionalityError):
                 ret = compute_energy_consumption_breakdown_for_building(
                     building_1, start_dt, end_dt, 1, "hour"


### PR DESCRIPTION
We need a default here to avoid crashes or complicated tests.

Let's decide that default is `""` which means dimensionless.