### PR TITLE
Catch OutOfBoundsDatetime when loading TS data

### DIFF
--- a/bemserver_core/input_output/timeseries_data_io.py
+++ b/bemserver_core/input_output/timeseries_data_io.py
@@ -399,7 +399,10 @@ def to_utc_index(series):
 
     try:
         index = pd.to_datetime(pd.Series(series))
-    except dateutil.parser._parser.ParserError as exc:
+    except (
+        dateutil.parser._parser.ParserError,
+        pd.errors.OutOfBoundsDatetime,
+    ) as exc:
         raise TimeseriesDataIODatetimeError("Invalid timestamp") from exc
 
     # We can't just use tz_convert because it would silently swallow naive datetimes

--- a/tests/input_output/test_timeseries_data_io.py
+++ b/tests/input_output/test_timeseries_data_io.py
@@ -1881,6 +1881,7 @@ class TestTimeseriesDataCSVIO:
             # Invalid timestamp
             ("dummy,1", TimeseriesDataIODatetimeError),
             ("0,1", TimeseriesDataIODatetimeError),
+            ("2500-01-01T00:00:00+00:00,12", TimeseriesDataIODatetimeError),
         ),
     )
     @pytest.mark.usefixtures("timeseries")
@@ -2446,6 +2447,7 @@ class TestTimeseriesDataJSONIO:
             # Invalid timestamp
             ('{"1324564": {"dummy": 1}}', TimeseriesDataIODatetimeError),
             ('{"1324564": [{"dummy": 1}]}', TimeseriesDataIODatetimeError),
+            ('{"1": {"2500-01-01T00:00:00+00:00": 1}}', TimeseriesDataIODatetimeError),
         ),
     )
     @pytest.mark.parametrize("for_campaign", (True,))  # False))


### PR DESCRIPTION
Avoids a crash when input data contains datetimes that pandas can't convert into Timestamps.

https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timestamp-limitations

We should also catch errors when e.g. getting data with bounds that are out of range, because this will fail too. For now, let's leave this to API validation and assume users using core know what they are doing.