### PR TITLE
Remove Python 3.11 support (for now)

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - {name: '3.9', python: '3.9', tox: py39}
-          - {name: '3.11', python: '3.11', tox: py311}
+          - {name: '3.10', python: '3.11', tox: py310}
           - {name: 'min', python: '3.9', tox: min}
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         "Topic :: Scientific/Engineering",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         (
             "License :: OSI Approved :: "
             "GNU Affero General Public License v3 or later (AGPLv3+)"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py39,py310,py311,min
+envlist = lint,py39,py310,min
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
It appears Celery 5.2.x doesn't support Python 3.11.

Let's wait for 5.3 (soon to be released).