### PR TITLE
Update bemserver-celery-settings.py

### DIFF
--- a/docs/deployment/srv/bemserver-core/application/bemserver-celery-settings.py
+++ b/docs/deployment/srv/bemserver-core/application/bemserver-celery-settings.py
@@ -9,9 +9,9 @@ beat_schedule = {
     },
     "check_missing": {
         "task": "CheckMissing",
-        "schedule": crontab(minute="0", hour="2", day="*"),
+        "schedule": crontab(minute="0", hour="2", day_of_month="*"),
         "kwargs": {
-            "timezone": "Europe/Paris",
+            "timezone": timezone,
             "min_completeness_ratio": 0.5,
             "period": "day",
             "period_multiplier": 1,
@@ -19,9 +19,9 @@ beat_schedule = {
     },
     "check_outliers": {
         "task": "CheckOutliers",
-        "schedule": crontab(minute="0", hour="2", day="*"),
+        "schedule": crontab(minute="0", hour="2", day_of_month="*"),
         "kwargs": {
-            "timezone": "Europe/Paris",
+            "timezone": timezone,
             "min_correctness_ratio": 0.5,
             "period": "day",
             "period_multiplier": 1,


### PR DESCRIPTION
Avoid to repeat timezone
Fix `BaseSchedule.__init__() got an unexpected keyword argument 'day'`